### PR TITLE
Addition of calcKearns function

### DIFF
--- a/ODFAnalysis/@ODF/calcKearns.m
+++ b/ODFAnalysis/@ODF/calcKearns.m
@@ -1,4 +1,4 @@
-function [f1,f2,f3] = Kearns(odf_o)
+function [f1,f2,f3] = calcKearns(odf_o)
 % Calculate Kearns factor of a hexagonal material
 % Input parameters
 %   odf_o=Orientation Distribution function, centred along direction 1;


### PR DESCRIPTION
Kearns factors are regularly used in texture analysis for engineering materials (e.g. zirconium parts in the nuclear industry).  I have written a short code to calculate Kearns factors from an ODF using the MTEX library and would like to share it with other MTEX users.
