### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -44,7 +44,7 @@ startup.m       initialization routine automticaly called by MATLAB if the
 startup_mtex    initialization routine for MTEX - to be called at the
                 beginning of each MTEX session
 tests (dir)     some self tests
-tools           auxilary tools
+tools           auxiliary tools
 unistall_mtex   remove MTEX from the search path (permanently)
 
 


### PR DESCRIPTION
mtex-toolbox, I've corrected a typographical error in the documentation of the [mtex](https://github.com/mtex-toolbox/mtex) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.