### PR TITLE
Modifications to ODF interpolation solver and PF to ODF reconstruct iteration controls

### DIFF
--- a/ODFAnalysis/@ODF/interp.m
+++ b/ODFAnalysis/@ODF/interp.m
@@ -22,7 +22,12 @@ odf = m * uniformODF(ori.CS,ori.SS);
 
 % grid for representing the ODF
 res = get_option(varargin,'resolution',3*degree);
-S3G = equispacedSO3Grid(ori.CS,ori.SS,'resolution',res);
+exact = get_option(varargin,'exact',false);
+if exact
+    S3G=ori;
+else
+    S3G = equispacedSO3Grid(ori.CS,ori.SS,'resolution',res);
+end
 
 % kernel for representing the ODF
 psi = get_option(varargin,'kernel',deLaValleePoussinKernel('halfwidth',res));
@@ -30,11 +35,52 @@ psi = get_option(varargin,'kernel',deLaValleePoussinKernel('halfwidth',res));
 % system matrix
 M = psi.K_symmetrised(S3G,ori,ori.CS,ori.SS);
 
-[w,flag,relres,iter,resvec] = lsqr(M',values,1e-2,30);
 
-% err = abs(M'*w - values);
-% disp(['   maximum error during interpolating ODF: ',xnum2str(max(err))]);
-% disp(['   mean error during interpolating ODF   : ',xnum2str(mean(err))]);
+has_toolbox_license = license('test', 'optimization_toolbox');
+has_lsqlin = ~isempty(which('lsqlin'));
+use_lsqlin = get_option(varargin,'lsqlin',false);
+
+if has_toolbox_license && has_lsqlin && use_lsqlin
+  tolCon = get_option(varargin,'lsqlin_tolCon',1e-10);
+  tolX = get_option(varargin,'lsqlin_tolX',1e-14);
+  tolFun = get_option(varargin,'lsqlin_tolFun',1e-10);
+  
+  options = optimoptions('lsqlin','Algorithm','interior-point',...
+      'Display','iter','TolCon',tolCon,'TolX',tolX,'TolFun',tolFun);
+  
+  [n1,n2] = size(M');
+  
+  [w,resnorm,residual,exitflag,output,lambda_lsqlin] = ...
+      lsqlin(M',values,-eye(n2,n2),zeros(n2,1),[],[],[],[],[],options);
+else
+  tol = get_option(varargin,'tol',1e-2);
+  iters = get_option(varargin,'iters',30);
+  [w,flag,relres,iter,resvec] = lsqr(M',values,tol,iters);
+  
+  %In case a user wants the best possible tolerence, just keep increasing
+  %tolerance
+  cnt=0;
+  while flag > 0
+     tolerance=tolerance*1.3; 
+     disp(['   lsqr tolerance cut back: ',xnum2str(max(tolerance))])
+     [w,flag,relres,iter,resvec] = lsqr(M',values,tolerance,50);
+     cnt=cnt+1; 
+     if cnt > 5
+          disp('   more than 5 lsqr tolerance cut backs')
+          disp('   consider using a larger tolerance')
+         break
+     end
+  end 
+end
+
+ODF_stats = get_option(varargin,'ODFstats',false);
+if ODF_stats
+ err = abs(M'*w - values);
+ disp(['   Minimum weight: ',xnum2str(min(w))]);
+ disp(['   Maximum weight:  : ',xnum2str(max(w))]);
+ disp(['   Maximum error during interpolating ODF: ',xnum2str(max(err))]);
+ disp(['   Mean error during interpolating ODF   : ',xnum2str(mean(err))]);
+end
 
 odf = odf + (1-m).*unimodalODF(S3G,psi,'weights',w./sum(w));
 

--- a/PoleFigureAnalysis/@MLSSolver/calcODF.m
+++ b/PoleFigureAnalysis/@MLSSolver/calcODF.m
@@ -8,6 +8,12 @@ end
 % initalize solver
 solver.init;
 
+% get max iterations and min iterations 
+solver.iterMax = get_option(varargin,'iterMax',10);
+solver.iterMin = get_option(varargin,'iterMin',5);
+if solver.iterMax < solver.iterMin
+    solver.iterMax=solver.iterMin;
+end
 % display
 format = [' %s |' repmat('  %1.2f',1,solver.pf.numPF) '\n'];
 


### PR DESCRIPTION

Hi Guys,

Using lsqr when reconstructing sharp textures can result in unexpected textures at ODF import. Decreasing the solver's tolerance results in a range of very different textures since negative weights are used to help fit strong components, thereby lowering the error, but diverging from a reasonable solution. I added lsqlin which enforces positive weights for the ODF interpolation. For very high-resolution ODFs (~3*degree) lsqlin becomes slow and of course, there is the issue of it requiring the optimization toolbox. For our group, having the lsqlin in MTEX would at least be beneficial.

Example: Using Neutron data exported from MAUD Rietveld analysis which can export both PFs and ODFs for reconstruction.

A pdf of a script output comparing PFs is below along with the files. 

[Reconstruction_Study.pdf](https://github.com/mtex-toolbox/mtex/files/3500026/Reconstruction_Study.pdf)
[1_Mg_phase.MAUD.txt](https://github.com/mtex-toolbox/mtex/files/3500029/1_Mg_phase.MAUD.txt)
[1_Mg_phase.xpc.txt](https://github.com/mtex-toolbox/mtex/files/3500030/1_Mg_phase.xpc.txt)
[Reconstruction_Study.m.txt](https://github.com/mtex-toolbox/mtex/files/3500031/Reconstruction_Study.m.txt)

Not surprisingly, the PF to ODF reconstruction method does a better job matching the experimental PFs and the lsqlin method does a better job matching the experimental ODF. For both methods, the spurious components in the ODF are smoothed out as expected.

Comparison with MAUD ODF:
lsqr method- err: 16172.7, err max: 91.9, err mean: 2.82
lsqlin method - err: 7339.6, err max: 104.7, err mean: 1.28
pf method 6 iterations - err: 8027.5, err max: 109.7, err mean: 1.40
pf method 20 iterations - err: 7868.6, err max: 105.6, err mean: 1.37