### PR TITLE
minor bug fix to Miller.m

### DIFF
--- a/geometry/@Miller/Miller.m
+++ b/geometry/@Miller/Miller.m
@@ -118,11 +118,11 @@ classdef Miller < vector3d
         if nparam < 3, error('You need at least 3 Miller indice!');end
         
         % check fourth coefficient is right
-        if nparam==4 && all(varargin{1} + varargin{2} + varargin{3} ~= 0)
+        if nparam==4 && all(abs(varargin{1} + varargin{2} + varargin{3}) > eps*10)
           if check_option(varargin,{'uvw','uvtw','direction'})
-            warning(['Convention u+v+t=0 violated! I assume t = ',int2str(-varargin{1} - varargin{2})]); %#ok<WNTAG>
+            warning(['Convention u+v+t=0 violated! I assume t = ',num2str(-varargin{1} - varargin{2})]); %#ok<WNTAG>
           else
-            warning(['Convention h+k+i=0 violated! I assume i = ',int2str(-varargin{1} - varargin{2})]); %#ok<WNTAG>
+            warning(['Convention h+k+i=0 violated! I assume i = ',num2str(-varargin{1} - varargin{2})]); %#ok<WNTAG>
           end
         end
         


### PR DESCRIPTION
Line 121: for 'uvtw' or 'hkil' I edited the coefficient checker to allow numerical precision errors, 't' and 'i' parameters are not used in any case.
Lines 123, 125: changed 'int2str' to 'num2str' as the input type is double, this avoids rounding confusion in the error messages.