### PR TITLE
Fix legend entry for crystal shape plot

### DIFF
--- a/geometry/@crystalShape/plot.m
+++ b/geometry/@crystalShape/plot.m
@@ -41,7 +41,7 @@ if check_option(varargin,'colored')
   end
   
   hold off
-  legend('show','interpreter','LaTeX','location','best')
+  legend({},'interpreter','LaTeX','location','best')
   
   if nargout == 0, clear h; end
   return


### PR DESCRIPTION
Legend entries only showed 'interpreter LaTeX' instead of the Miller indices when using the 'colored' option for plotting crystal shapes.