### PR TITLE
assign nan to face centers of absent faces

### DIFF
--- a/geometry/@crystalShape/crystalShape.m
+++ b/geometry/@crystalShape/crystalShape.m
@@ -132,10 +132,13 @@ classdef crystalShape
     
     function fC = get.faceCenter(cS)
       fC = vector3d.zeros(size(cS.F,1),1);
-      for i = 1:length(fC)
-        VId = cS.F(i,:); VId = VId(~isnan(VId));
-        fC(i) = centroid(cS.V(VId));
-      end
+      if any(~isnan(cS.F(i,:)))
+                VId = cS.F(i,:); VId = VId(~isnan(VId));
+                fC(i) = centroid(cS.V(VId));
+          else
+              fC(i)=nan;
+          end
+        end
     end
     
     function cSVol = get.volume(cS) 

--- a/geometry/@crystalShape/crystalShape.m
+++ b/geometry/@crystalShape/crystalShape.m
@@ -132,13 +132,14 @@ classdef crystalShape
     
     function fC = get.faceCenter(cS)
       fC = vector3d.zeros(size(cS.F,1),1);
-      if any(~isnan(cS.F(i,:)))
-                VId = cS.F(i,:); VId = VId(~isnan(VId));
-                fC(i) = centroid(cS.V(VId));
-          else
-              fC(i)=nan;
-          end
+      for i = 1:length(fC)
+        if any(~isnan(cS.F(i,:)))
+          VId = cS.F(i,:); VId = VId(~isnan(VId));
+          fC(i) = centroid(cS.V(VId));
+        else
+          fC(i)=nan;
         end
+      end
     end
     
     function cSVol = get.volume(cS) 


### PR DESCRIPTION
An example code to replicate an error:
cs=loadCIF('olivin');
N = Miller({1,0,0},{0,0,1},{1,1,1},{0,1,0},{1,1,0},{1,0,1},{0,1,1},cs); %Poles
d = [0.643, 1.372, 1.148, 0.964, 0.825, 1.045, 1.287];

cShape = crystalShape(d.*N);
figure; plot(cShape)
% plot Miller idx labels
N = unique(cShape.N.symmetrise,'noSymmetry','stable');
fC = cShape.faceCenter;

for i = 1:length(N)
  text3(fC(i),char(round(N(i)),'latex'),'scaling',1.1,'interpreter','latex')
end