### PR TITLE
Include option for title alignment

### DIFF
--- a/compatibility/mtexTitle.m
+++ b/compatibility/mtexTitle.m
@@ -42,7 +42,7 @@ end
 if check_option(varargin,'alignLeftOutside')
         set(h, 'horizontalAlignment', 'left');
         set(h, 'units', 'normalized');
-        h.position(1)=0;
+        h.Position(1)=0;
 elseif check_option(varargin,'alignLeftInside')
         set(h, 'horizontalAlignment', 'left');
         set(h, 'units', 'normalized');

--- a/compatibility/mtexTitle.m
+++ b/compatibility/mtexTitle.m
@@ -5,7 +5,9 @@ function h = mtexTitle(s,varargin)
 %
 %   mtexTitle('title of the current axis')
 %   mtexTitle('title of all subplots','global')
-%
+%   mtexTitle('title of the current axis','alignLeftOutside')
+%   mtexTitle('title of the current axis','alignLeftInside')
+
 
 %s = regexprep(s,'-(\d)','\\bar{$1}');
 %s = regexprep(s,'-(\d)','\\bar{$1}');
@@ -35,6 +37,17 @@ else
     'interpreter','LaTeX','FontSize',round(getMTEXpref('FontSize')*1.1)),varargin{:});
 
   set(get(ax,'Title'),'Visible','on');
+end
+
+if check_option(varargin,'alignLeftOutside')
+        set(h, 'horizontalAlignment', 'left');
+        set(h, 'units', 'normalized');
+        h.position(1)=0;
+elseif check_option(varargin,'alignLeftInside')
+        set(h, 'horizontalAlignment', 'left');
+        set(h, 'units', 'normalized');
+        h1 = get(h, 'position');
+        set(h, 'position', [0 0.9 h1(3)])% 10% below
 end
 
 try


### PR DESCRIPTION
Add option to align text to left side (outside or inside). This allows for publication-ready numbering of sub plots. e.g.:

f=newMtexFigure; f.outerPlotSpacing=20; lettersT='abcdefgh';
for ii=1:3
    plot(vector3d.rand(100,1),'lower')
    mtexTitle([lettersT(ii),')'],'alignLeftOutside');
    if ii~=3;f.nextAxis;end
end
