### PR TITLE
Return correct coordinate from Miller.i

### DIFF
--- a/geometry/@Miller/Miller.m
+++ b/geometry/@Miller/Miller.m
@@ -221,7 +221,7 @@ classdef Miller < vector3d
     
     function h = get.h(m), h = m.hkl(:,1);end
     function k = get.k(m), k = m.hkl(:,2);end
-    function i = get.i(m), i = m.hkl(:,3);end
+    function i = get.i(m), i = m.hkil(:,3);end
     function l = get.l(m), l = m.hkl(:,end);end
         
     % ------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Hi,

and thanks *a lot* for this amazing software.

I think currently `Miller.i` returns `Miller.l`, which this PR should fix.

Before this change

```matlab
>> cs = crystalSymmetry('1');
>> m = Miller(1, 0, 2, cs, 'hkl');
>> disp(m.hkil)
1     0    -1     2
>> disp(m.i)
2
```

After this change

```matlab
>> cs = crystalSymmetry('1');
>> m = Miller(1, 0, 2, cs, 'hkl');
>> disp(m.hkil)
1     0    -1     2
>> disp(m.i)
-1
```
