### PR TITLE
make deviatoricStress suitable for stress of length n

### DIFF
--- a/TensorAnalysis/@stressTensor/deviatoricStress.m
+++ b/TensorAnalysis/@stressTensor/deviatoricStress.m
@@ -14,7 +14,7 @@ function sigma = deviatoricStress(sigma,varargin)
 
 
 p = meanStress(sigma);
-
+p = reshape(p,[1,1,length(sigma)]);
 sigma.M(1,1,:) = sigma.M(1,1,:) - p;
 sigma.M(2,2,:) = sigma.M(2,2,:) - p;
 sigma.M(3,3,:) = sigma.M(3,3,:) - p;


### PR DESCRIPTION
Fix 'Matrix dimensions must agree.' when trying to compute the deviatoric stress for stress tensor of length ~=1