### PR TITLE
Round distances to rotated centers in project2fundamentalRegion

### DIFF
--- a/geometry/@vector3d/project2FundamentalRegion.m
+++ b/geometry/@vector3d/project2FundamentalRegion.m
@@ -75,6 +75,10 @@ end
 
 dist = dot_outer(v,symCenter,'noSymmetry');
 
+% Round distances so that if any of them are equal, the first rotated
+% center is chosen
+dist = round(dist, 12);
+
 [~,col] = max(dist,[],2);
 
 v = reshape(inv(subSet(cs,col)),size(v)) .* v;


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

This is a fix for #1245.

Some vectors with azimuthal angles equal to zero can sometimes be projected to the other side of the fundamental region with `vector3d.project2fundamentalRegion`. I believe this rounding to the 12th decimal should make sure the correct (first) rotated region center is chosen in the next evaluation of the maximum distance.

The only tests I've made are to make sure that the IPF color keys in #1245 now look correct. The rounding integer, 12, was found by trial.