### PR TITLE
Don't convert quaternion coefficients to degrees in export

### DIFF
--- a/geometry/@quaternion/export.m
+++ b/geometry/@quaternion/export.m
@@ -25,7 +25,7 @@ function export(q,fname,varargin)
 %  quaternion - export quaternion values
 %  Bunge      - export Bunge Euler angles (default)
 %  Matthies   - export Matthies Euler angles (alpha beta gamma)
-%  degree     - output in degree (default)
+%  degree     - output in degree (default, unless 'quaternion' is passed)
 %  radians    - output in radians
 
 if check_option(varargin,'quaternion')
@@ -38,10 +38,10 @@ else
   % add Euler angles
   [d,columnNames] = q.Euler(varargin{:});
 
-end
-  
-if ~check_option(varargin,{'radians','radiant','radiand'})
-  d = d ./ degree;
+  if ~check_option(varargin,{'radians','radiant','radiand'})
+    d = d ./ degree;
+  end
+
 end
 
 % export additional properties


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Writing quaternion coefficients to file

```matlab
>> q = quaternion.rand(5)
q = quaternion (show methods, plot)
  size: 5 x 1
           a          b          c          d
  -0.0648726  -0.809528   0.342683   0.472254
     0.37502  -0.837579  -0.162312  -0.362596
   -0.425613  -0.288554 -0.0593885  -0.855607
    0.236986   0.740326  -0.626879  -0.052697
    -0.24426  -0.448668  0.0160699   0.859521
>> export(q, 'quaternions.txt', 'quaternion')
```

assumes they are angles in radians and converts them to degrees

```matlab
>> type quaternions.txt  % Shows content of text file
       a        b        c        d
-3.71692 -46.3825  19.6343  27.0582
 21.4871 -47.9897  -9.2998 -20.7752
-24.3858 -16.5329 -3.40271 -49.0227
 13.5783  42.4176 -35.9175 -3.01932
-13.9951 -25.7068 0.920736  49.2469
```

while with this PR, whether 'radians' is passed or not is ignored when 'quaternion' is passed, as expected

```matlab
>> type quaternions.txt
         a          b          c          d
-0.0648726  -0.809528   0.342683   0.472254
   0.37502  -0.837579  -0.162312  -0.362596
 -0.425613  -0.288554 -0.0593885  -0.855607
  0.236986   0.740326  -0.626879  -0.052697
  -0.24426  -0.448668  0.0160699   0.859521
```