### PR TITLE
Bug fix: show correct orientation id on pole figure tooltip

### DIFF
--- a/plotting/@mtexFigure/getDataCursorPos.m
+++ b/plotting/@mtexFigure/getDataCursorPos.m
@@ -71,7 +71,10 @@ else
 end
 
 if nargin > 1
-  id = ceil(id*maxId/numel(xd));
+	id = mod(id,maxId);
+	if id == 0
+		id = maxId;
+	end
 end
 
 end


### PR DESCRIPTION
Hi,

First of all, thank you for making such a great toolbox.

This PR is to address an issue that using `plotPDF(orientations)` does not show the correct `id` in the tooltip (therefore the associated Euler angle is also incorrect). The details of this issue can be found in [https://github.com/mtex-toolbox/mtex/discussions/1109](https://github.com/mtex-toolbox/mtex/discussions/1109).

This change can be easily tested by the following code:
```matlab
CS = crystalSymmetry('6/mmm',[2.95 2.95 4.68], [90 90 120]*degree);
m = Miller({0 0 0 1},{1 1 -2 0},CS);
% plot 10 random orientations
ori = orientation.rand(10,CS);
plotPDF(ori, m)
% now click on the figure and get the id showing from the tooltip
% then plot that orientation on the same figure to see if they match
hold on
plotPDF(ori(id), m) 
```
Before this change, plotting `ori(id)` does not match with the selected one. This PR fixes it.

A detailed explanation of this change can be found in [https://github.com/mtex-toolbox/mtex/discussions/1109#discussioncomment-5110774](https://github.com/mtex-toolbox/mtex/discussions/1109#discussioncomment-5110774).