### PR TITLE
Speed up calcGrains by removing setSubset

### DIFF
--- a/EBSDAnalysis/@EBSD/calcGrains.m
+++ b/EBSDAnalysis/@EBSD/calcGrains.m
@@ -130,12 +130,15 @@ end
 
 % compute mean orientation and GOS
 doMeanCalc = find(grains.grainSize>1 & grains.isIndexed);
+abcd = zeros(length(doMeanCalc),4);
 for k = 1:numel(doMeanCalc)
   qind = subSet(q,d(grainRange(doMeanCalc(k))+1:grainRange(doMeanCalc(k)+1)));
   mq = mean(qind,'robust');
-  meanRotation = setSubSet(meanRotation,doMeanCalc(k),mq);
+  abcd(k,:) = [mq.a mq.b mq.c mq.d];
   GOS(doMeanCalc(k)) = mean(angle(mq,qind)); 
 end
+
+meanRotation(doMeanCalc)=reshape(quaternion(abcd'),[],1);
 
 % save 
 grains.prop.GOS = GOS;

--- a/EBSDAnalysis/@EBSD/calcGrains.m
+++ b/EBSDAnalysis/@EBSD/calcGrains.m
@@ -125,21 +125,20 @@ for pId = grains.indexedPhasesId
   q(d(ndx)) = project2FundamentalRegion(q(d(ndx)),ebsd.CSList{pId},meanRotation(g(ndx)));
 end
 
-
-% TODO: this can be done more efficiently using accumarray
-
 % compute mean orientation and GOS
-doMeanCalc = find(grains.grainSize>1 & grains.isIndexed);
-abcd = zeros(length(doMeanCalc),4);
-for k = 1:numel(doMeanCalc)
-  qind = subSet(q,d(grainRange(doMeanCalc(k))+1:grainRange(doMeanCalc(k)+1)));
-  mq = mean(qind,'robust');
-  abcd(k,:) = [mq.a mq.b mq.c mq.d];
-  GOS(doMeanCalc(k)) = mean(angle(mq,qind)); 
+if 0
+  doMeanCalc = find(grains.grainSize>1 & grains.isIndexed);
+  abcd = zeros(length(doMeanCalc),4);
+  for k = 1:numel(doMeanCalc)
+    qind = subSet(q,d(grainRange(doMeanCalc(k))+1:grainRange(doMeanCalc(k)+1)));
+    mq = mean(qind,'robust');
+    abcd(k,:) = [mq.a mq.b mq.c mq.d];
+    GOS(doMeanCalc(k)) = mean(angle(mq,qind)); 
+  end
+  meanRotation(doMeanCalc)=reshape(quaternion(abcd'),[],1);
+else
+  [meanRotation, GOS] = accumarray(grainId,q,'robust');
 end
-
-meanRotation(doMeanCalc)=reshape(quaternion(abcd'),[],1);
-
 % save 
 grains.prop.GOS = GOS;
 grains.prop.meanRotation = reshape(meanRotation,[],1);

--- a/geometry/@quaternion/accumarray.m
+++ b/geometry/@quaternion/accumarray.m
@@ -1,4 +1,4 @@
-function q = accumarray(subs,q,varargin)
+function [q, GOS] = accumarray(subs,q,varargin)
 % accumarray for quaternion
 %
 % Syntax
@@ -10,6 +10,9 @@ function q = accumarray(subs,q,varargin)
 %
 % Output
 %  q - @quaternion
+
+isRobust = check_option(varargin,'robust');
+varargin = delete_option(varargin,'robust');
 
 % find a reference quaternion for each class
 ref = accumarray(subs,1:length(q),[],@(x) x(1));
@@ -24,6 +27,33 @@ d = accumarray(subs,q.d .* flip,varargin{:});
 
 % normalize
 s = sqrt(a.^2 + b.^2 + c.^2 + d.^2);
-q.a = a ./ s; q.b = b ./ s; q.c = c ./ s; q.d = d ./ s;
 
+if isRobust
+  % compute the fit
+  omega = real(acos(flip./s(subs) .* ...
+    (q.a .* a(subs) + q.b .* b(subs) + q.c .* c(subs) + q.d .* d(subs))));
+
+  % compute the threshold
+  threshold = 2.5*accumarray(subs,omega,size(a),@(x) quantile(x,0.8));
+  ind = omega <= threshold(subs);
+
+  Rsubs = subs(ind);
+  Rflip = flip(ind);
+  a = accumarray(Rsubs,q.a(ind) .* Rflip,varargin{:});
+  b = accumarray(Rsubs,q.b(ind) .* Rflip,varargin{:});
+  c = accumarray(Rsubs,q.c(ind) .* Rflip,varargin{:});
+  d = accumarray(Rsubs,q.d(ind) .* Rflip,varargin{:});
+
+  % normalize
+  s = sqrt(a.^2 + b.^2 + c.^2 + d.^2);
+end
+
+% compute spread for each cluster
+if nargout == 2
+  omega = real(acos(flip./s(subs) .* ...
+    (q.a .* a(subs) + q.b .* b(subs) + q.c .* c(subs) + q.d .* d(subs))));
+  GOS = accumarray(subs,omega,size(a),@mean);
+end
+
+q.a = a ./ s; q.b = b ./ s; q.c = c ./ s; q.d = d ./ s;
 if isa(q,'rotation'), q.i = q_ref.i(ref); end


### PR DESCRIPTION
calcGrains is quite slow for maps with large amounts (over 100 000) grains due to calling setSubset so many times. The patch stores the quaternion values and replaces all the meanRotation values after the loop is concluded. This speeds up calcGrains significantly for large datasets.