### PR TITLE
Display p2cfit in parentGrainReconstructor only when desired

### DIFF
--- a/EBSDAnalysis/@parentGrainReconstructor/display.m
+++ b/EBSDAnalysis/@parentGrainReconstructor/display.m
@@ -20,7 +20,7 @@ cprintf(matrix,'-L',' ','-Lc',...
   {'phase' 'mineral' 'symmetry' 'grains' 'area' 'reconstructed'},...
   '-d','  ','-ic',true,'-la','T');
 
-if ~isempty(job.p2c)
+if ~isempty(job.p2c) & job.reportFit
   disp(' ');
   disp([' OR: ' char(job.p2c)]);
   prop = calcGBFit(job,'p2c','quick')./degree;

--- a/EBSDAnalysis/@parentGrainReconstructor/parentGrainReconstructor.m
+++ b/EBSDAnalysis/@parentGrainReconstructor/parentGrainReconstructor.m
@@ -48,7 +48,8 @@ classdef parentGrainReconstructor < handle
     grains         % grains at the current stage of reconstruction
     p2c            % parent to child orientation relationship
     useBoundaryOrientations = false
-    
+    reportFit = true
+
     mergeId        % a list of ids to the merged grains
     
     votes          % votes computed by calcGBVotes or calcTPVotes


### PR DESCRIPTION
It takes a long time for older machines to display the fit of p2c fit. For batch workflows there should be a possibility to skip displaying it if desired.