### PR TITLE
meanProp output size

### DIFF
--- a/EBSDAnalysis/@EBSD/grainMean.m
+++ b/EBSDAnalysis/@EBSD/grainMean.m
@@ -55,6 +55,10 @@ meanProp = accumarray(ebsd.grainId(hasGrain),prop(hasGrain),[],method);
 
 % convert from id to ind
 grains = getClass(varargin,'grain2d');
-if ~isempty(grains), meanProp = meanProp(grains.id); end
+if  ~isempty(grains)
+    meanProp = meanProp(grains.id);
+else
+    meanProp = meanProp(ebsd.grainId);
+end
 
 end


### PR DESCRIPTION
Option to make output either the same size & order as ebsd.grainId or grains.id (if specified), to construct either grain area-weighted or grain number-weighted distributions