### PR TITLE
add possibility of removing visibility to MTEXFigure

### DIFF
--- a/plotting/@mtexFigure/mtexFigure.m
+++ b/plotting/@mtexFigure/mtexFigure.m
@@ -105,7 +105,8 @@ classdef mtexFigure < handle
       
       clf('reset');
       rmallappdata(gcf);
-      set(gcf,'Visible','on');
+      vis = get_option(varargin,'Visible','on');
+      set(gcf,'Visible',vis);
 
       % set figure name
       if ~isempty(get_option(varargin,'FigureTitle'))


### PR DESCRIPTION
Instead of forcing visibility of, it can be allowed by passing the "Visible","on" option. Useful if you want to export figures without paying the overhead of displaying them.
