### PR TITLE
fix EBSD position concatenation

### DIFF
--- a/EBSDAnalysis/@EBSD/cat.m
+++ b/EBSDAnalysis/@EBSD/cat.m
@@ -19,4 +19,5 @@ for k = 2:numel(varargin)
   ebsd.phaseId = cat(1,ebsd.phaseId,varargin{k}.phaseId);
   ebsd.id = cat(1,ebsd.id,varargin{k}.id);
   ebsd.rotations = cat(1,ebsd.rotations,varargin{k}.rotations);
+  ebsd.pos = cat(1,ebsd.pos,varargin{k}.pos);
 end


### PR DESCRIPTION
Was working with the MTEX 6.0.beta2 release and found that the EBSD data position vector did not update properly when concatenating EBSD data. This change seems to fix the issue.