### PR TITLE
fix rare crash

### DIFF
--- a/plotting/@mtexFigure/private/calcAxesSize.m
+++ b/plotting/@mtexFigure/private/calcAxesSize.m
@@ -14,7 +14,7 @@ if nargin <= 2, nc = mtexFig.ncols; nr = mtexFig.nrows; end
 % compute axes lenght ratio
 axesSize = get(mtexFig.children(1),'PlotBoxAspectRatio');
 cd = get(mtexFig.children(1),'CameraPosition')-get(mtexFig.children(1),'CameraTarget');
-axesSize(cd == max(abs(cd))) = [];
+axesSize(find(cd == max(abs(cd)),1)) = [];
 
 if find(get(mtexFig.children(1),'CameraUpVector'))==1
   axesRatio = axesSize(1)/axesSize(2);


### PR DESCRIPTION
I managed to encounter a reproduceable situation where line 17 removed _two_ entries from axesSize rather than one (as two of the three entries in cd were equal to the maximum value), which resulted in the following lines throwing an error after trying to access element 2 of axesSize. This change should ensure that line 17 only ever removes one element from axesSize.