### PR TITLE
order boundary segments during grain reconstrucion

### DIFF
--- a/EBSDAnalysis/@grainBoundary/grainBoundary.m
+++ b/EBSDAnalysis/@grainBoundary/grainBoundary.m
@@ -46,6 +46,7 @@ classdef grainBoundary < phaseList & dynProp
   
   % general properties
   properties
+    segments = []   % list of boundary segments as [v1 v2 v3 NaN v4 v5]
     scanUnit = 'um' % unit of the vertex coordinates
     triplePoints = triplePointList  % triple points
   end


### PR DESCRIPTION
Boundary segments should be ordered between triplepoints already during grain reconstruction 