### PR TITLE
Update jcvoronoi_mex.cpp

### DIFF
--- a/extern/jcvoronoi/jcvoronoi_mex.cpp
+++ b/extern/jcvoronoi/jcvoronoi_mex.cpp
@@ -73,12 +73,12 @@ public:
         }
         jcv_diagram_free(&diagram);
 
-        outputs[0] = factory.createArray((ArrayDimensions){(size_t)Vx.size(),1},Vx.begin(),Vx.end());
-        outputs[1] = factory.createArray((ArrayDimensions){(size_t)Vy.size(),1},Vy.begin(),Vy.end());
-        outputs[2] = factory.createArray((ArrayDimensions){(size_t)E1.size(),1},E1.begin(),E1.end());
-        outputs[3] = factory.createArray((ArrayDimensions){(size_t)E2.size(),1},E2.begin(),E2.end());
-        outputs[4] = factory.createArray((ArrayDimensions){(size_t)I_ED1.size(),1},I_ED1.begin(),I_ED1.end());
-        outputs[5] = factory.createArray((ArrayDimensions){(size_t)I_ED2.size(),1},I_ED2.begin(),I_ED2.end());
+        outputs[0] = factory.createArray(ArrayDimensions{(size_t)Vx.size(),1},Vx.begin(),Vx.end());
+        outputs[1] = factory.createArray(ArrayDimensions{(size_t)Vy.size(),1},Vy.begin(),Vy.end());
+        outputs[2] = factory.createArray(ArrayDimensions{(size_t)E1.size(),1},E1.begin(),E1.end());
+        outputs[3] = factory.createArray(ArrayDimensions{(size_t)E2.size(),1},E2.begin(),E2.end());
+        outputs[4] = factory.createArray(ArrayDimensions{(size_t)I_ED1.size(),1},I_ED1.begin(),I_ED1.end());
+        outputs[5] = factory.createArray(ArrayDimensions{(size_t)I_ED2.size(),1},I_ED2.begin(),I_ED2.end());
 
       free(points);
     }


### PR DESCRIPTION
Hello!

I tried to compile the jcvoronoi_mex.cpp in Matlab, which resulted in errors when using Visual Studio C++ compiler. When I removed the brackets around "ArrayDimensions", the mex file compiled. The resulting file was strangely much smaller than the mex file in the actual mex folder.

Using the newly compiled mex file results in expected grain map and I no longer experience the memory issue, at least when I tested on three files where this issue has previously appeared.

-Tuomo