### PR TITLE
fix plottingConvention.m

### DIFF
--- a/plotting/plottingConvention.m
+++ b/plotting/plottingConvention.m
@@ -123,23 +123,23 @@ classdef plottingConvention < handle
 
 
     function v = get.outOfScreen(pC), v = pC.rot * vector3d.Z; end
-    function set.outOfScreen(pC,n), pC.rot = rotation.map(pC.outOfScreen,n) * pC.rot; end
+    function set.outOfScreen(pC,n), pC.rot = rotation.map(pC.outOfScreen,n,pC.east,pC.east) * pC.rot; end
 
     function v = get.intoScreen(pC), v = -pC.rot * vector3d.Z; end
-    function set.intoScreen(pC,n), pC.rot = rotation.map(pC.outOfScreen,-n) * pC.rot; end
+    function set.intoScreen(pC,n), pC.rot = rotation.map(pC.outOfScreen,-n,pC.east,pC.east) * pC.rot; end
 
 
     function v = get.east(pC), v = pC.rot * vector3d.X; end
-    function set.east(pC,e), pC.rot = rotation.map(pC.east,e) * pC.rot; end
+    function set.east(pC,e), pC.rot = rotation.map(pC.east,e,pC.outOfScreen,pC.outOfScreen) * pC.rot; end
 
     function v = get.west(pC), v = -pC.rot * vector3d.X; end
-    function set.west(pC,w), pC.rot = rotation.map(pC.east,-w) * pC.rot; end
+    function set.west(pC,w), pC.rot = rotation.map(pC.east,-w,pC.outOfScreen,pC.outOfScreen) * pC.rot; end
 
     function v = get.north(pC), v = pC.rot * vector3d.Y; end
-    function set.north(pC,v), pC.rot = rotation.map(pC.north,v) * pC.rot; end
+    function set.north(pC,v), pC.rot = rotation.map(pC.north,v,pC.outOfScreen,pC.outOfScreen) * pC.rot; end
     
     function v = get.south(pC), v = -pC.rot * vector3d.Y; end
-    function set.south(pC,v), pC.rot = rotation.map(pC.north,-v) * pC.rot; end
+    function set.south(pC,v), pC.rot = rotation.map(pC.north,-v,pC.outOfScreen,pC.outOfScreen) * pC.rot; end
 
 
     function plot(pC, varargin)


### PR DESCRIPTION
I think rotation.map in set.east/north etc. needs a second vector pair to define the correct rotation

otherwise you can accidentally change the first screen direction when setting the other one in the constructor: 
```matlab
pC = plottingConvention(vector3d.Z,-vector3d.X)
 % pC = plottingConvention
 % 
 %  outOfScreen: (0,0,-1)
 %  north      : (0,1,0) 
 %  east       : (-1,0,0)

pC.rot
% ans = rotation
%
% Bunge Euler angles in degree
% phi1  Phi phi2
%   90  180  270

pC.outOfScreen
% ans = vector3d
%   x  y  z
%   0  0 -1
% % this is wrong

% try to set outOfScreen again
pC.outOfScreen = vector3d.Z
pC.rot
% pC = plottingConvention
% 
%   outOfScreen: (0,0,1) 
%   north      : (0,-1,0)
%   east       : (-1,0,0)
% 
% ans = rotation
% 
%   Bunge Euler angles in degree
%   phi1  Phi phi2
%    180    0    0

pC.outOfScreen
% ans = vector3d
%   x y z
%   0 0 1
% this is now correct
```