### PR TITLE
force copy constructor to inherit plottingConvention

### DIFF
--- a/EBSDAnalysis/@EBSD/EBSD.m
+++ b/EBSDAnalysis/@EBSD/EBSD.m
@@ -86,6 +86,7 @@ classdef EBSD < phaseList & dynProp & dynOption
         ebsd.unitCell = rot.unitCell;
         ebsd.scanUnit = rot.scanUnit;
         ebsd.A_D = rot.A_D;
+        ebsd.plottingConvention = pos.plottingConvention;
         for fn = fieldnames(rot.prop)'
           ebsd.prop.(char(fn))= rot.prop.(char(fn))(:);
         end


### PR DESCRIPTION
so if you do
ebsd2 = ebsd1;
you don't lose the plottingConvention set by ebsd1 

Feature request: can we set the plottingConvention property explicitly in the @EBSD constructor (and do this for @EBSDsquare/hex as well, so that you don't lose this information after gridify?) 
(I am not sure how to do this correctly for a dependent property / child class.)