### PR TITLE
Correct a false dislocation strain energy formulae in the documentation  (in GND.m)

### DIFF
--- a/doc/Plasticity/GND.m
+++ b/doc/Plasticity/GND.m
@@ -174,21 +174,19 @@ a = norm(ebsd.CS.aAxis);
 %
 % $$ U_{\mathrm{screw}} = \frac{Gb^2}{4\pi} \ln \frac{R}{r_0} $$
 %
-% $$ U_{\mathrm{edge}} = (1-\nu) U_{\mathrm{screw}} $$
+% $$ U_{\mathrm{edge}} = \frac{1}{(1-\nu)} U_{\mathrm{screw}} $$
 %
 % where
 % 
-% * |G| is 
+% * |G| is the shear modulus
 % * |b| is the length of the Burgers vector
 % * |nu| is the Poisson ratio
 % * |R|
 % * |r|
 %
 % In this example we assume 
-% 
-% R = 
-% r_0 = 
-% U = norm(dS.b).^2
+% $$ U_{\mathrm{edge}} = 1 $$
+% $$ U_{\mathrm{screw}} = 1-\nu $$
 
 nu = 0.3;
 


### PR DESCRIPTION
The formulae present in the Geometrically Necessary Dislocation page of the documentation for calculating the strain energy of an Edge dislocation is wrong, this commit aims to correct it.
You can find the formulae in Chapter 4 of the following book : Hull, D., et D. J. Bacon. « Elastic Properties of Dislocations ». Introduction to Dislocations, Elsevier, 2011, p. 63‑83. DOI.org (Crossref), https://doi.org/10.1016/B978-0-08-096672-4.00004-9. 