### PR TITLE
EBSD.pos bug fix

### DIFF
--- a/EBSDAnalysis/@EBSD/EBSD.m
+++ b/EBSDAnalysis/@EBSD/EBSD.m
@@ -110,7 +110,7 @@ classdef EBSD < phaseList & dynProp & dynOption
         if size(pos,2)==3
           pos = vector3d.byXYZ(pos);
         else
-          pos = vector3d.byXYZ(pos(:,1),pos(:,2),0);
+          pos = vector3d(pos(:,1),pos(:,2),0);
         end
       end
       ebsd.pos = pos;


### PR DESCRIPTION
3 numeric inputs should call the vector3d constructor, not byXYZ