### PR TITLE
fix: disable diary during disptmp printing

### DIFF
--- a/extern/dipstat/disptmp.m
+++ b/extern/dipstat/disptmp.m
@@ -2,6 +2,12 @@ function disptmp(s,varargin)
 
 global prevCharCnt;
 
+% \b doesn't work on logs, so turn diary off temporarily
+if strcmp(get(0,'Diary'),'on')
+    diary('off')
+    turn_diary_on_when_done = onCleanup(@() diary('on'));
+end
+
 if isempty(prevCharCnt) || ~isempty(lastwarn), prevCharCnt = 0; end
 lastwarn('');
 % Make safe for fprintf, replace control charachters


### PR DESCRIPTION
`\b` doesn't work on logs, so [`diary`](https://uk.mathworks.com/help/matlab/ref/diary.html) should be turned off (temporarily) when printing `progress` messages, otherwise you get a file with thousands of lines of the sort:

```
estimating optimal kernel halfwidth: 0%
 estimate optimal kernel halfwidth: 2%
 estimate optimal kernel halfwidth: 4%
 estimate optimal kernel halfwidth: 6%
 estimate optimal kernel halfwidth: 8%
 estimate optimal kernel halfwidth: 10%
```