### PR TITLE
bug fix for set grainId to 0

### DIFF
--- a/EBSDAnalysis/@EBSD/EBSD.m
+++ b/EBSDAnalysis/@EBSD/EBSD.m
@@ -235,8 +235,10 @@ classdef EBSD < phaseList & dynProp & dynOption
 
       % phaseId should be the same within one grain 
       ind = ebsd.grainId>0;
+      if nnz(ind)
       grain2phaseId = majorityVote(ebsd.grainId(ind),ebsd.phaseId(ind));
       ebsd.phaseId(ind) = grain2phaseId(ebsd.grainId(ind));
+      end
       
     end
       


### PR DESCRIPTION
only reassign phaseId for if for points ebsd.grainId>0

otherwise majorityVote function errors when trying to reassign an empty array