### PR TITLE
replace underscore with dash to improve map plot legends

### DIFF
--- a/tools/misc_tools/makeDisjoint.m
+++ b/tools/misc_tools/makeDisjoint.m
@@ -1,5 +1,5 @@
 function strList = makeDisjoint(strList)
-% make string list disjoint by appending _1, _2 if required
+% make string list disjoint by appending -1, -2 if required
 %
 % Syntax
 %   strList = makeDisjoint(strList)
@@ -14,6 +14,6 @@ function strList = makeDisjoint(strList)
 strList = string(strList);
 strList = strList(:);
 A = sum(tril(strList == strList.'),2);
-strList(A>1) = strList(A>1) + "_" + A(A>1);
+strList(A>1) = strList(A>1) + "-" + A(A>1);
 
 end


### PR DESCRIPTION
avoid appending with an underscore e.g. phase_2 is interpreted as a subscript when plotting map legends
New: <img width="181" height="149" alt="phase Co-2" src="https://github.com/user-attachments/assets/94437d2e-ef83-4829-ba0f-a3aac5b24b23" />
Old: <img width="181" height="149" alt="phase Co_2" src="https://github.com/user-attachments/assets/16ef9e1d-2940-43f5-a8d5-696f242a41cf" />
