### PR TITLE
update import wizard for new matlab versions

### DIFF
--- a/interfaces/import_wizard/private/WizardFinish.m
+++ b/interfaces/import_wizard/private/WizardFinish.m
@@ -206,7 +206,9 @@ end
       if ~getMTEXpref('SaveToFile')
         try
           EditorServices = com.mathworks.mlservices.MLEditorServices;
-          if ~verLessThan('matlab','7.11')
+          if ~verLessThan('matlab','9.13')
+             matlab.desktop.editor.newDocument(str);
+          elseif ~verLessThan('matlab','7.11')
             EditorServices.getEditorApplication.newEditor(str);
           else
             EditorServices.newDocument(str,true);
@@ -562,3 +564,4 @@ end
   end
 
 end
+


### PR DESCRIPTION
MATLAB syntax for new .m file creation starting R2022b (v9.13)

https://uk.mathworks.com/matlabcentral/answers/1911675-how-to-replace-com-mathworks-mlservices-mleditorservices-geteditorapplication-getactiveeditor-to-fin