### PR TITLE
bug fix calcUnitCell.m

### DIFF
--- a/interfaces/tools/calcUnitCell.m
+++ b/interfaces/tools/calcUnitCell.m
@@ -90,7 +90,7 @@ try
   unitCell(ignore,:) = [];
     
   % third estimate of the grid resolution
-  dxy2 = min(vecnorm(unitCell.',2));
+  dxy2 = vecnorm(unitCell,2,1);
 catch
   unitCell = [];
 end
@@ -175,3 +175,4 @@ while length(xy) > N
     xy(:,2)>yminmax(1) & xy(:,2)<yminmax(2),:);
   
 end
+


### PR DESCRIPTION
grid resolution estimate dxy2 should be [dx dy]. Old version gave unit cell diagonal half-length. 