### PR TITLE
Complete inner grain boundaries with anchored shortest paths

### DIFF
--- a/EBSDAnalysis/@EBSD/calcGrains.m
+++ b/EBSDAnalysis/@EBSD/calcGrains.m
@@ -36,7 +36,8 @@ function [grains,ebsd] = calcGrains(ebsd,varargin)
 %  custom    - use a custom property for grain separation
 %
 % Flags
-%  completeBoundaries - enforce detected boundaries by local minimum cuts
+%  completeBoundaries - enforce detected boundaries by local minimum cuts;
+%    enclosed inner-boundary fragments shorter than three segments are ignored
 %  unitCell - omit Voronoi decomposition and treat a unitcell lattice
 %  qhull    - use qHull for the Voronoi decomposition
 %  delaunay - use a true circumradius-based alpha-complex (exact, not a
@@ -84,7 +85,7 @@ F = out.F;
 I_FD = remapIFD(out,ebsd);
 
 % determine which cells to connect
-[A_Db,I_DG] = doSegmentation(I_FD,ebsd,gbc,varargin{:});
+[A_Db,I_DG] = doSegmentation(I_FD,F,ebsd,gbc,varargin{:});
 % A_db - neighboring cells with (inner) grain boundary
 % I_DG - incidence matrix cells to grains
 

--- a/EBSDAnalysis/@EBSD/calcGrains.m
+++ b/EBSDAnalysis/@EBSD/calcGrains.m
@@ -36,7 +36,7 @@ function [grains,ebsd] = calcGrains(ebsd,varargin)
 %  custom    - use a custom property for grain separation
 %
 % Flags
-%  completeBoundaries - enforce detected boundaries by local minimum cuts;
+%  completeBoundaries - extend detected boundaries to non-inner boundaries;
 %    enclosed inner-boundary fragments shorter than three segments are ignored
 %  unitCell - omit Voronoi decomposition and treat a unitcell lattice
 %  qhull    - use qHull for the Voronoi decomposition

--- a/EBSDAnalysis/@EBSD/calcGrains.m
+++ b/EBSDAnalysis/@EBSD/calcGrains.m
@@ -36,6 +36,7 @@ function [grains,ebsd] = calcGrains(ebsd,varargin)
 %  custom    - use a custom property for grain separation
 %
 % Flags
+%  completeBoundaries - enforce detected boundaries by local minimum cuts
 %  unitCell - omit Voronoi decomposition and treat a unitcell lattice
 %  qhull    - use qHull for the Voronoi decomposition
 %  delaunay - use a true circumradius-based alpha-complex (exact, not a

--- a/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
+++ b/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
@@ -1,26 +1,27 @@
 function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db,I_FD,F)
-% extend inner boundaries by recursively applying local minimum cuts
+% extend inner boundaries to existing non-inner boundaries
 %
 % Input
-%  A_Do - weighted adjacency of connected pixels
+%  A_Do - logical adjacency of connected pixels
 %  A_Db - logical adjacency of pixel pairs marked as grain boundaries
 %  I_FD - incidence matrix faces -> pixels
 %  F    - vertex ids of the boundary segments
 %
 % Output
 %  A_Do        - connectivity after the additional cuts
-%  A_Db        - original and additionally introduced boundary edges
+%  A_Db        - retained and additionally introduced boundary edges
 %  componentId - connected component of every pixel
 %
-% A boundary edge is inner if its incident pixels are connected by an
-% alternative path in A_Do. For each affected component this function
-% repeatedly separates the endpoints of one such edge by a minimum cut.
-% Every cut strictly increases the number of components, and hence the
-% procedure terminates with no inner boundary edges.
+% The Voronoi segments form the planar dual of the pixel adjacency graph.
+% Retained inner-boundary segments are extended through this dual graph until
+% every free end reaches an existing non-inner boundary. An augmentation may
+% connect different boundary components, but never two ends of the same
+% component. Hence newly introduced segments cannot close into an isolated
+% loop around a pixel.
 %
-% The individual binary cuts are optimal with respect to the weights in
-% A_Do. The sequence of cuts is a greedy multicut approximation; it is not
-% a globally optimal solution of the multicut problem.
+% Every augmentation uses the smallest available number of new segments.
+% The sequence of shortest paths is greedy; it is not a globally optimal
+% Steiner forest.
 %
 % Isolated inner-boundary components with fewer than three segments are
 % ignored. They usually originate from individual noisy pixels. Segment
@@ -29,238 +30,331 @@ function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db,I_FD,F)
 
 n = size(A_Do,1);
 
-% A boundary is a hard separation constraint. This is relevant for soft or
-% low-angle criteria, for which an edge can currently occur in both graphs.
+% A detected boundary is initially a hard separation constraint. This is
+% relevant for soft criteria, for which an edge can occur in both graphs.
 A_Do = A_Do - A_Do .* A_Db;
-
-[bdI,bdJ] = find(triu(A_Db,1));
 componentId = connectedComponents(A_Do);
+componentColumn = componentId(:);
 
-if isempty(bdI), return; end
+topology = faceIncidence(I_FD);
+if isempty(topology.pair), return; end
 
-isInner = componentId(bdI) == componentId(bdJ);
+pairIndex = sub2ind(size(A_Db),topology.pair(:,1),topology.pair(:,2));
+isBoundary = full(A_Db(pairIndex)) ~= 0;
+isInner = isBoundary & ...
+  componentColumn(topology.pair(:,1)) == componentColumn(topology.pair(:,2));
 if ~any(isInner), return; end
 
-% Remove short, enclosed boundary fragments before running any max-flow.
-% Apart from suppressing pixel noise this is important for performance:
-% every ignored fragment avoids a potentially grain-sized flow problem.
-[ignoreI,ignoreJ] = shortIsolatedBoundaries(A_Db,componentId,I_FD,F);
-if ~isempty(ignoreI)
-  ignored = sparse([ignoreI;ignoreJ],[ignoreJ;ignoreI],true,n,n);
+% Suppress short enclosed fragments before constructing any shortest-path
+% problem. Ignored faces become ordinary within-grain connections.
+ignoreRow = shortIsolatedBoundaryRows(topology,F,isBoundary,isInner, ...
+  componentColumn);
+if ~isempty(ignoreRow)
+  ignoredPair = topology.pair(ignoreRow,:);
+  ignored = sparse([ignoredPair(:,1);ignoredPair(:,2)], ...
+    [ignoredPair(:,2);ignoredPair(:,1)],true,n,n);
   A_Db = A_Db - A_Db .* ignored;
-
-  % Treat an ignored fragment as ordinary within-grain connectivity. This
-  % is also the intended behaviour for a hard (zero-connectivity) criterion.
   A_Do = A_Do | ignored;
 
-  [bdI,bdJ] = find(triu(A_Db,1));
-  isInner = componentId(bdI) == componentId(bdJ);
+  isBoundary = full(A_Db(pairIndex)) ~= 0;
+  isInner = isBoundary & ...
+    componentColumn(topology.pair(:,1)) == componentColumn(topology.pair(:,2));
   if ~any(isInner), return; end
 end
 
-% Collect only the affected pixels in linear time. Sorting all component ids
-% used to be noticeable for multi-million-pixel maps.
-affectedId = unique(componentId(bdI(isInner)));
-affectedLookup = zeros(n,1,'uint32');
-affectedLookup(affectedId) = uint32(1:numel(affectedId));
-affectedPosition = affectedLookup(componentId(:));
-affectedPixel = find(affectedPosition);
-pixelGroups = accumarray(double(affectedPosition(affectedPixel)),affectedPixel, ...
-  [numel(affectedId),1],@(x) {x});
+addedFaceId = anchoredBoundaryFaces(A_Do,isBoundary,isInner, ...
+  componentColumn,topology,F);
 
-cutI = cell(numel(affectedId),1);
-cutJ = cell(numel(affectedId),1);
+if ~isempty(addedFaceId)
+  pairRowOfFace = zeros(size(F,1),1,'uint32');
+  pairRowOfFace(topology.pairFaceId) = uint32(1:size(topology.pair,1));
+  addedRow = double(pairRowOfFace(addedFaceId));
+  if any(addedRow == 0)
+    error('MTEX:calcGrains:boundaryCompletionFailed', ...
+      'A completed boundary contains a face without two incident pixels.');
+  end
 
-for k = 1:numel(affectedId)
-  pixels = pixelGroups{k};
-
-  A = A_Do(pixels,pixels);
-  B = A_Db(pixels,pixels);
-  [dI,dJ] = find(triu(B,1));
-
-  [localI,localJ] = completeComponent(A,dI,dJ);
-  cutI{k} = pixels(localI);
-  cutJ{k} = pixels(localJ);
-end
-
-cutI = vertcat(cutI{:});
-cutJ = vertcat(cutJ{:});
-
-if ~isempty(cutI)
-  added = sparse([cutI;cutJ],[cutJ;cutI],true,n,n);
+  addedPair = unique(sort(topology.pair(addedRow,:),2),'rows');
+  added = sparse([addedPair(:,1);addedPair(:,2)], ...
+    [addedPair(:,2);addedPair(:,1)],true,n,n);
   A_Do = A_Do - A_Do .* added;
   A_Db = A_Db | added;
-  componentId = connectedComponents(A_Do);
 end
 
+componentId = connectedComponents(A_Do);
+[bdI,bdJ] = find(triu(A_Db,1));
 if any(componentId(bdI) == componentId(bdJ))
   error('MTEX:calcGrains:boundaryCompletionFailed', ...
-    'Boundary completion left an inner grain-boundary constraint.');
+    ['Boundary completion could not anchor every retained inner boundary ' ...
+    'at non-inner boundaries.']);
 end
 
 end
 
 % -------------------------------------------------------------------------
-function [cutI,cutJ] = completeComponent(A,dI,dJ)
-% complete all boundary constraints within one initially connected component
+function topology = faceIncidence(I_FD)
+% extract paired and single-pixel faces from a sparse face incidence matrix
 
-n = size(A,1);
-numDemands = numel(dI);
-cutI = cell(numDemands,1);
-cutJ = cell(numDemands,1);
-numCuts = 0;
-
-% Each queue entry is already connected and contains only constraints whose
-% endpoints lie in that block. After a cut, only child blocks with unresolved
-% constraints are queued. Thus later max-flow and component computations run
-% on progressively smaller graphs rather than repeatedly on the original
-% grain.
-nodeQueue = cell(2*numDemands+1,1);
-demandQueue = cell(2*numDemands+1,1);
-nodeQueue{1} = (1:n).';
-demandQueue{1} = (1:numDemands).';
-head = 1;
-tail = 1;
-blockPosition = zeros(n,1);
-
-while head <= tail
-  nodes = nodeQueue{head};
-  demands = demandQueue{head};
-  head = head + 1;
-
-  numNodes = numel(nodes);
-  blockPosition(nodes) = 1:numNodes;
-  posI = blockPosition(dI(demands));
-  posJ = blockPosition(dJ(demands));
-  ABlock = A(nodes,nodes);
-
-  % Prefer a constraint whose endpoints are well connected to their
-  % surroundings. This reduces the tendency of an unconstrained s-t cut to
-  % isolate a single boundary pixel.
-  degree = full(sum(ABlock,2));
-  score = min(degree(posI),degree(posJ));
-  [~,iBest] = max(score);
-  source = posI(iBest);
-  target = posJ(iBest);
-
-  [edgeI,edgeJ,weight] = find(triu(ABlock,1));
-  G = graph(double(edgeI),double(edgeJ),double(weight),numNodes);
-  [~,~,sourceNodes] = maxflow(G,source,target);
-
-  sourceSide = false(numNodes,1);
-  sourceSide(sourceNodes) = true;
-  isCut = sourceSide(edgeI) ~= sourceSide(edgeJ);
-
-  if ~any(isCut)
-    error('MTEX:calcGrains:boundaryCompletionFailed', ...
-      'Could not separate an inner grain-boundary constraint.');
-  end
-
-  numCuts = numCuts + 1;
-  cutI{numCuts} = nodes(edgeI(isCut));
-  cutJ{numCuts} = nodes(edgeJ(isCut));
-
-  % Split only the two sides of this cut. The source side is normally
-  % connected already; connectedComponents also handles the rare case in
-  % which the other side contains several components.
-  for onSourceSide = [true false]
-    demandOnSide = sourceSide(posI) == onSourceSide & ...
-      sourceSide(posJ) == onSourceSide;
-    if ~any(demandOnSide), continue; end
-
-    childLocal = find(sourceSide == onSourceSide);
-    childComponent = connectedComponents(ABlock(childLocal,childLocal));
-
-    componentInBlock = zeros(numNodes,1);
-    componentInBlock(childLocal) = childComponent;
-    demandComponent = componentInBlock(posI(demandOnSide));
-    sameComponent = demandComponent == componentInBlock(posJ(demandOnSide));
-    if ~any(sameComponent), continue; end
-
-    childDemands = demands(demandOnSide);
-    childDemands = childDemands(sameComponent);
-    demandComponent = demandComponent(sameComponent);
-
-    componentIds = unique(demandComponent);
-    for iComponent = 1:numel(componentIds)
-      cId = componentIds(iComponent);
-      tail = tail + 1;
-      nodeQueue{tail} = nodes(childLocal(childComponent == cId));
-      demandQueue{tail} = childDemands(demandComponent == cId);
-    end
-  end
-end
-
-cutI = vertcat(cutI{1:numCuts});
-cutJ = vertcat(cutJ{1:numCuts});
-
-end
-
-% -------------------------------------------------------------------------
-function [ignoreI,ignoreJ] = shortIsolatedBoundaries(A_Db,componentId,I_FD,F)
-% find enclosed inner-boundary components with fewer than three segments
-
-ignoreI = zeros(0,1);
-ignoreJ = zeros(0,1);
-componentId = componentId(:);
-
-nFaces = size(I_FD,1);
-if nFaces == 0 || size(F,1) ~= nFaces || size(F,2) ~= 2, return; end
-
-% Extract paired and single-pixel faces directly from the sparse incidence
-% list. Avoiding a dense nFaces-by-2 array matters for large maps.
 I_FDt = I_FD.';
 [pixelId,faceId] = find(I_FDt);
-if isempty(faceId), return; end
+
+if isempty(faceId)
+  topology.pairFaceId = zeros(0,1);
+  topology.pair = zeros(0,2);
+  topology.singleFaceId = zeros(0,1);
+  topology.singlePixel = zeros(0,1);
+  return;
+end
 
 sameAsPrevious = [false; faceId(2:end) == faceId(1:end-1)];
 sameAsNext = [faceId(1:end-1) == faceId(2:end); false];
-pairFaceId = faceId(sameAsPrevious);
-pair = [pixelId(sameAsNext),pixelId(sameAsPrevious)];
-singleFaceId = faceId(~sameAsPrevious & ~sameAsNext);
 
-pairIndex = sub2ind(size(A_Db),pair(:,1),pair(:,2));
-isBoundary = full(A_Db(pairIndex)) ~= 0;
-isInner = isBoundary & ...
-  componentId(pair(:,1)) == componentId(pair(:,2));
-if ~any(isInner), return; end
+topology.pairFaceId = faceId(sameAsPrevious);
+topology.pair = [pixelId(sameAsNext),pixelId(sameAsPrevious)];
+isSingle = ~sameAsPrevious & ~sameAsNext;
+topology.singleFaceId = faceId(isSingle);
+topology.singlePixel = pixelId(isSingle);
 
-innerFaceId = pairFaceId(isInner);
+end
+
+% -------------------------------------------------------------------------
+function ignoreRow = shortIsolatedBoundaryRows(topology,F,isBoundary, ...
+  isInner,componentId)
+% find enclosed inner-boundary components with fewer than three segments
+
+innerRow = find(isInner);
+innerFaceId = topology.pairFaceId(innerRow);
 innerSegments = double(F(innerFaceId,:));
-if any(innerSegments(:) < 1), return; end
 
-% Boundary segments are connected exactly when their rows in F share a
-% Voronoi vertex. Only the (usually small) set of inner segments enters this
-% sparse product.
+if isempty(innerSegments) || any(innerSegments(:) < 1)
+  ignoreRow = zeros(0,1);
+  return;
+end
+
 numInner = numel(innerFaceId);
-numVertices = double(max(F(:)));
-I_VB = sparse(innerSegments(:),[(1:numInner).';(1:numInner).'], ...
-  true,numVertices,numInner);
+[~,~,innerVertexGroup] = unique(innerSegments(:));
+I_VB = sparse(innerVertexGroup,[(1:numInner).';(1:numInner).'], ...
+  true,max(innerVertexGroup),numInner);
 boundaryComponent = connectedComponents(I_VB.' * I_VB);
 boundaryComponent = boundaryComponent(:);
 
-% Existing inter-grain boundaries and the exterior of the measured map both
-% count as outer boundaries.
 isOuterPair = isBoundary & ...
-  componentId(pair(:,1)) ~= componentId(pair(:,2));
-outerFaceId = [singleFaceId;pairFaceId(isOuterPair)];
-
-outerVertex = false(numVertices,1);
+  componentId(topology.pair(:,1)) ~= componentId(topology.pair(:,2));
+outerFaceId = [topology.singleFaceId;topology.pairFaceId(isOuterPair)];
 outerSegments = double(F(outerFaceId,:));
-outerSegments = outerSegments(outerSegments > 0);
-outerVertex(outerSegments) = true;
-touchesOuter = any(outerVertex(innerSegments),2);
+outerVertex = unique(outerSegments(outerSegments > 0));
+touchesOuter = any(ismember(innerSegments,outerVertex),2);
 
 numComponents = max(boundaryComponent);
-componentSize = accumarray(boundaryComponent(:),1,[numComponents 1]);
-componentTouchesOuter = accumarray(boundaryComponent(:),touchesOuter, ...
+componentSize = accumarray(boundaryComponent,ones(size(boundaryComponent)), ...
+  [numComponents 1]);
+componentTouchesOuter = accumarray(boundaryComponent,touchesOuter, ...
   [numComponents 1],@(x) any(x),false);
 
 ignore = componentSize(boundaryComponent) < 3 & ...
   ~componentTouchesOuter(boundaryComponent);
-innerPairs = pair(isInner,:);
-ignoredPairs = unique(sort(innerPairs(ignore,:),2),'rows');
-ignoreI = ignoredPairs(:,1);
-ignoreJ = ignoredPairs(:,2);
+ignoreRow = innerRow(ignore);
+
+end
+
+% -------------------------------------------------------------------------
+function addedFaceId = anchoredBoundaryFaces(A_Do,isBoundary,isInner, ...
+  componentId,topology,F)
+% complete each affected grain in the dual boundary-segment graph
+
+pairIndex = sub2ind(size(A_Do),topology.pair(:,1),topology.pair(:,2));
+isConnected = full(A_Do(pairIndex)) ~= 0;
+pairComponent1 = componentId(topology.pair(:,1));
+pairComponent2 = componentId(topology.pair(:,2));
+
+affectedId = unique(pairComponent1(isInner));
+addedByComponent = cell(numel(affectedId),1);
+
+for iComponent = 1:numel(affectedId)
+  gId = affectedId(iComponent);
+
+  innerRow = find(isInner & pairComponent1 == gId);
+  innerFaceId = topology.pairFaceId(innerRow);
+
+  candidateRow = find(isConnected & pairComponent1 == gId & ...
+    pairComponent2 == gId);
+  candidateFaceId = topology.pairFaceId(candidateRow);
+
+  isOuterPair = isBoundary & ...
+    ((pairComponent1 == gId) ~= (pairComponent2 == gId));
+  isOuterSingle = componentId(topology.singlePixel) == gId;
+  outerFaceId = [topology.pairFaceId(isOuterPair); ...
+    topology.singleFaceId(isOuterSingle)];
+  outerVertex = unique(double(F(outerFaceId,:)));
+  outerVertex = outerVertex(outerVertex > 0);
+
+  addedByComponent{iComponent} = completeBoundaryNetwork(F,innerFaceId, ...
+    candidateFaceId,outerVertex);
+end
+
+addedFaceId = vertcat(addedByComponent{:});
+
+end
+
+% -------------------------------------------------------------------------
+function addedFaceId = completeBoundaryNetwork(F,boundaryFaceId, ...
+  candidateFaceId,outerVertex)
+% join every non-outer boundary endpoint to a different network or the outer
+
+originalFaceId = boundaryFaceId;
+addedFaceId = zeros(0,1);
+
+while true
+  [faceComponent,endPoint,endPointComponent,boundaryVertex, ...
+    boundaryVertexComponent] = boundaryNetworkInfo(F,boundaryFaceId);
+
+  isOuterEnd = ismember(endPoint,outerVertex);
+  freeEnd = endPoint(~isOuterEnd);
+  freeEndComponent = endPointComponent(~isOuterEnd);
+
+  if isempty(freeEnd)
+    numComponents = max(faceComponent);
+    numEnds = accumarray(endPointComponent,ones(size(endPointComponent)), ...
+      [numComponents 1]);
+    if any(numEnds == 0)
+      error('MTEX:calcGrains:boundaryCompletionLoop', ...
+        ['A retained inner boundary forms a closed loop that cannot be ' ...
+        'anchored without connecting the boundary to itself.']);
+    end
+    break;
+  end
+
+  bestLength = inf;
+  bestPathFace = zeros(0,1);
+
+  % Choose the globally shortest admissible next augmentation. Targets may
+  % be outer-boundary vertices or free ends of a different boundary network.
+  for iEnd = 1:numel(freeEnd)
+    source = freeEnd(iEnd);
+    sourceComponent = freeEndComponent(iEnd);
+    sourceBoundaryVertex = ...
+      boundaryVertex(boundaryVertexComponent == sourceComponent);
+
+    outerTarget = outerVertex(~ismember(outerVertex,sourceBoundaryVertex));
+    otherEndTarget = endPoint(endPointComponent ~= sourceComponent);
+    target = unique([outerTarget;otherEndTarget]);
+    if isempty(target), continue; end
+
+    [pathFaceId,pathLength] = shortestBoundaryPath(F,candidateFaceId, ...
+      source,target,boundaryVertex);
+
+    if pathLength < bestLength
+      bestLength = pathLength;
+      bestPathFace = pathFaceId;
+    end
+  end
+
+  if isempty(bestPathFace)
+    error('MTEX:calcGrains:boundaryCompletionFailed', ...
+      ['Could not extend a free inner-boundary end to a different boundary ' ...
+      'network or a non-inner boundary.']);
+  end
+
+  boundaryFaceId = [boundaryFaceId;bestPathFace];
+  addedFaceId = [addedFaceId;bestPathFace]; %#ok<AGROW>
+
+  used = ismember(candidateFaceId,bestPathFace);
+  candidateFaceId(used) = [];
+end
+
+% Every returned face is an actual addition, even if input data contained
+% duplicate segment ids.
+addedFaceId = setdiff(unique(addedFaceId),originalFaceId,'stable');
+
+end
+
+% -------------------------------------------------------------------------
+function [faceComponent,endPoint,endPointComponent,boundaryVertex, ...
+  boundaryVertexComponent] = boundaryNetworkInfo(F,boundaryFaceId)
+% components and free ends of the current boundary-segment network
+
+segments = double(F(boundaryFaceId,:));
+numFaces = numel(boundaryFaceId);
+[boundaryVertex,~,vertexGroup] = unique(segments(:));
+I_VB = sparse(vertexGroup,[(1:numFaces).';(1:numFaces).'], ...
+  true,numel(boundaryVertex),numFaces);
+faceComponent = connectedComponents(I_VB.' * I_VB);
+faceComponent = faceComponent(:);
+
+vertexDegree = accumarray(vertexGroup,1);
+boundaryVertexComponent = accumarray(vertexGroup, ...
+  [faceComponent;faceComponent],[],@max);
+
+isEnd = vertexDegree == 1;
+endPoint = boundaryVertex(isEnd);
+endPointComponent = boundaryVertexComponent(isEnd);
+
+end
+
+% -------------------------------------------------------------------------
+function [pathFaceId,pathLength] = shortestBoundaryPath(F,candidateFaceId, ...
+  source,target,boundaryVertex)
+% shortest candidate-face path from source to any admissible target
+
+pathFaceId = zeros(0,1);
+pathLength = inf;
+if isempty(candidateFaceId), return; end
+
+candidateSegments = double(F(candidateFaceId,:));
+[~,~,localId] = unique([candidateSegments(:,1);candidateSegments(:,2); ...
+  boundaryVertex(:);target(:);source]);
+numCandidate = size(candidateSegments,1);
+numBoundaryVertex = numel(boundaryVertex);
+numTarget = numel(target);
+
+localI = localId(1:numCandidate);
+localJ = localId(numCandidate+1:2*numCandidate);
+boundaryLocal = localId(2*numCandidate+1: ...
+  2*numCandidate+numBoundaryVertex);
+targetLocal = localId(2*numCandidate+numBoundaryVertex+1: ...
+  2*numCandidate+numBoundaryVertex+numTarget);
+sourceLocal = localId(end);
+
+blocked = false(max(localId),1);
+blocked(boundaryLocal) = true;
+blocked(sourceLocal) = false;
+blocked(targetLocal) = false;
+active = ~blocked(localI) & ~blocked(localJ);
+if ~any(active), return; end
+
+activeFaceId = candidateFaceId(active);
+localI = localI(active);
+localJ = localJ(active);
+
+% The local ids above avoid graph objects with millions of isolated vertices
+% when only one grain of a large EBSD map is affected.
+superTarget = max(localId) + 1;
+
+G = graph([localI;targetLocal],[localJ; ...
+  repmat(superTarget,numel(targetLocal),1)],[],superTarget);
+[pathLocal,pathLength] = shortestpath(G,sourceLocal,superTarget, ...
+  'Method','unweighted');
+if isempty(pathLocal) || ~isfinite(pathLength), return; end
+
+pathLocal(end) = []; % remove the artificial super-target
+pathLength = pathLength - 1;
+if numel(pathLocal) < 2
+  pathLength = inf;
+  return;
+end
+
+numLocalVertices = max(localId);
+edgeKey = double(min(localI,localJ)-1) * numLocalVertices + ...
+  double(max(localI,localJ));
+pathKey = double(min(pathLocal(1:end-1),pathLocal(2:end))-1) * ...
+  numLocalVertices + double(max(pathLocal(1:end-1),pathLocal(2:end)));
+[isCandidate,pathPosition] = ismember(pathKey,edgeKey);
+if ~all(isCandidate)
+  pathFaceId = zeros(0,1);
+  pathLength = inf;
+  return;
+end
+
+pathFaceId = activeFaceId(pathPosition);
 
 end

--- a/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
+++ b/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
@@ -1,0 +1,133 @@
+function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db)
+% extend inner boundaries by recursively applying local minimum cuts
+%
+% Input
+%  A_Do - weighted adjacency of connected pixels
+%  A_Db - logical adjacency of pixel pairs marked as grain boundaries
+%
+% Output
+%  A_Do        - connectivity after the additional cuts
+%  A_Db        - original and additionally introduced boundary edges
+%  componentId - connected component of every pixel
+%
+% A boundary edge is inner if its incident pixels are connected by an
+% alternative path in A_Do. For each affected component this function
+% repeatedly separates the endpoints of one such edge by a minimum cut.
+% Every cut strictly increases the number of components, and hence the
+% procedure terminates with no inner boundary edges.
+%
+% The individual binary cuts are optimal with respect to the weights in
+% A_Do. The sequence of cuts is a greedy multicut approximation; it is not
+% a globally optimal solution of the multicut problem.
+
+n = size(A_Do,1);
+
+% A boundary is a hard separation constraint. This is relevant for soft or
+% low-angle criteria, for which an edge can currently occur in both graphs.
+A_Do = A_Do - A_Do .* A_Db;
+
+[bdI,bdJ] = find(triu(A_Db,1));
+componentId = connectedComponents(A_Do);
+
+if isempty(bdI), return; end
+
+isInner = componentId(bdI) == componentId(bdJ);
+if ~any(isInner), return; end
+
+% Determine the pixels of every affected component without scanning the
+% complete pixel array once per grain.
+[sortedId,pixelOrder] = sort(componentId(:));
+first = [1; find(diff(sortedId)) + 1];
+last = [first(2:end) - 1; n];
+presentId = sortedId(first);
+
+firstOf = zeros(max(componentId),1);
+lastOf = zeros(max(componentId),1);
+firstOf(presentId) = first;
+lastOf(presentId) = last;
+
+affectedId = unique(componentId(bdI(isInner)));
+cutI = cell(numel(affectedId),1);
+cutJ = cell(numel(affectedId),1);
+
+for k = 1:numel(affectedId)
+  gId = affectedId(k);
+  pixels = pixelOrder(firstOf(gId):lastOf(gId));
+
+  A = A_Do(pixels,pixels);
+  B = A_Db(pixels,pixels);
+  [dI,dJ] = find(triu(B,1));
+
+  [localI,localJ] = completeComponent(A,dI,dJ);
+  cutI{k} = pixels(localI);
+  cutJ{k} = pixels(localJ);
+end
+
+cutI = vertcat(cutI{:});
+cutJ = vertcat(cutJ{:});
+
+if ~isempty(cutI)
+  added = sparse([cutI;cutJ],[cutJ;cutI],true,n,n);
+  A_Do = A_Do - A_Do .* added;
+  A_Db = A_Db | added;
+  componentId = connectedComponents(A_Do);
+end
+
+if any(componentId(bdI) == componentId(bdJ))
+  error('MTEX:calcGrains:boundaryCompletionFailed', ...
+    'Boundary completion left an inner grain-boundary constraint.');
+end
+
+end
+
+% -------------------------------------------------------------------------
+function [cutI,cutJ] = completeComponent(A,dI,dJ)
+% complete all boundary constraints within one initially connected component
+
+n = size(A,1);
+cutI = cell(0,1);
+cutJ = cell(0,1);
+componentId = connectedComponents(A);
+
+while true
+  isInner = componentId(dI) == componentId(dJ);
+  if ~any(isInner), break; end
+
+  % Prefer a constraint whose two endpoints are well connected to their
+  % surroundings. This reduces the tendency of an unconstrained s-t cut to
+  % isolate a single boundary pixel.
+  candidates = find(isInner);
+  degree = full(sum(A,2));
+  score = min(degree(dI(candidates)),degree(dJ(candidates)));
+  [~,iBest] = max(score);
+  iDemand = candidates(iBest);
+  source = dI(iDemand);
+  target = dJ(iDemand);
+
+  [edgeI,edgeJ,weight] = find(triu(A,1));
+  G = graph(double(edgeI),double(edgeJ),double(weight),n);
+  [~,~,sourceSide] = maxflow(G,source,target);
+
+  inSource = false(n,1);
+  inSource(sourceSide) = true;
+  isCut = inSource(edgeI) ~= inSource(edgeJ);
+
+  if ~any(isCut)
+    error('MTEX:calcGrains:boundaryCompletionFailed', ...
+      'Could not separate an inner grain-boundary constraint.');
+  end
+
+  newI = edgeI(isCut);
+  newJ = edgeJ(isCut);
+  cutI{end+1,1} = newI; %#ok<AGROW>
+  cutJ{end+1,1} = newJ; %#ok<AGROW>
+
+  cut = sparse([newI;newJ],[newJ;newI],true,n,n);
+  A = A - A .* cut;
+  componentId = connectedComponents(A);
+end
+
+cutI = vertcat(cutI{:});
+cutJ = vertcat(cutJ{:});
+
+end

--- a/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
+++ b/EBSDAnalysis/@EBSD/private/completeBoundaryGraph.m
@@ -1,9 +1,11 @@
-function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db)
+function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db,I_FD,F)
 % extend inner boundaries by recursively applying local minimum cuts
 %
 % Input
 %  A_Do - weighted adjacency of connected pixels
 %  A_Db - logical adjacency of pixel pairs marked as grain boundaries
+%  I_FD - incidence matrix faces -> pixels
+%  F    - vertex ids of the boundary segments
 %
 % Output
 %  A_Do        - connectivity after the additional cuts
@@ -19,6 +21,11 @@ function [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db)
 % The individual binary cuts are optimal with respect to the weights in
 % A_Do. The sequence of cuts is a greedy multicut approximation; it is not
 % a globally optimal solution of the multicut problem.
+%
+% Isolated inner-boundary components with fewer than three segments are
+% ignored. They usually originate from individual noisy pixels. Segment
+% connectivity is determined from F, so a short inner boundary that reaches
+% an existing grain or map boundary is retained.
 
 n = size(A_Do,1);
 
@@ -34,25 +41,38 @@ if isempty(bdI), return; end
 isInner = componentId(bdI) == componentId(bdJ);
 if ~any(isInner), return; end
 
-% Determine the pixels of every affected component without scanning the
-% complete pixel array once per grain.
-[sortedId,pixelOrder] = sort(componentId(:));
-first = [1; find(diff(sortedId)) + 1];
-last = [first(2:end) - 1; n];
-presentId = sortedId(first);
+% Remove short, enclosed boundary fragments before running any max-flow.
+% Apart from suppressing pixel noise this is important for performance:
+% every ignored fragment avoids a potentially grain-sized flow problem.
+[ignoreI,ignoreJ] = shortIsolatedBoundaries(A_Db,componentId,I_FD,F);
+if ~isempty(ignoreI)
+  ignored = sparse([ignoreI;ignoreJ],[ignoreJ;ignoreI],true,n,n);
+  A_Db = A_Db - A_Db .* ignored;
 
-firstOf = zeros(max(componentId),1);
-lastOf = zeros(max(componentId),1);
-firstOf(presentId) = first;
-lastOf(presentId) = last;
+  % Treat an ignored fragment as ordinary within-grain connectivity. This
+  % is also the intended behaviour for a hard (zero-connectivity) criterion.
+  A_Do = A_Do | ignored;
 
+  [bdI,bdJ] = find(triu(A_Db,1));
+  isInner = componentId(bdI) == componentId(bdJ);
+  if ~any(isInner), return; end
+end
+
+% Collect only the affected pixels in linear time. Sorting all component ids
+% used to be noticeable for multi-million-pixel maps.
 affectedId = unique(componentId(bdI(isInner)));
+affectedLookup = zeros(n,1,'uint32');
+affectedLookup(affectedId) = uint32(1:numel(affectedId));
+affectedPosition = affectedLookup(componentId(:));
+affectedPixel = find(affectedPosition);
+pixelGroups = accumarray(double(affectedPosition(affectedPixel)),affectedPixel, ...
+  [numel(affectedId),1],@(x) {x});
+
 cutI = cell(numel(affectedId),1);
 cutJ = cell(numel(affectedId),1);
 
 for k = 1:numel(affectedId)
-  gId = affectedId(k);
-  pixels = pixelOrder(firstOf(gId):lastOf(gId));
+  pixels = pixelGroups{k};
 
   A = A_Do(pixels,pixels);
   B = A_Db(pixels,pixels);
@@ -85,49 +105,162 @@ function [cutI,cutJ] = completeComponent(A,dI,dJ)
 % complete all boundary constraints within one initially connected component
 
 n = size(A,1);
-cutI = cell(0,1);
-cutJ = cell(0,1);
-componentId = connectedComponents(A);
+numDemands = numel(dI);
+cutI = cell(numDemands,1);
+cutJ = cell(numDemands,1);
+numCuts = 0;
 
-while true
-  isInner = componentId(dI) == componentId(dJ);
-  if ~any(isInner), break; end
+% Each queue entry is already connected and contains only constraints whose
+% endpoints lie in that block. After a cut, only child blocks with unresolved
+% constraints are queued. Thus later max-flow and component computations run
+% on progressively smaller graphs rather than repeatedly on the original
+% grain.
+nodeQueue = cell(2*numDemands+1,1);
+demandQueue = cell(2*numDemands+1,1);
+nodeQueue{1} = (1:n).';
+demandQueue{1} = (1:numDemands).';
+head = 1;
+tail = 1;
+blockPosition = zeros(n,1);
 
-  % Prefer a constraint whose two endpoints are well connected to their
+while head <= tail
+  nodes = nodeQueue{head};
+  demands = demandQueue{head};
+  head = head + 1;
+
+  numNodes = numel(nodes);
+  blockPosition(nodes) = 1:numNodes;
+  posI = blockPosition(dI(demands));
+  posJ = blockPosition(dJ(demands));
+  ABlock = A(nodes,nodes);
+
+  % Prefer a constraint whose endpoints are well connected to their
   % surroundings. This reduces the tendency of an unconstrained s-t cut to
   % isolate a single boundary pixel.
-  candidates = find(isInner);
-  degree = full(sum(A,2));
-  score = min(degree(dI(candidates)),degree(dJ(candidates)));
+  degree = full(sum(ABlock,2));
+  score = min(degree(posI),degree(posJ));
   [~,iBest] = max(score);
-  iDemand = candidates(iBest);
-  source = dI(iDemand);
-  target = dJ(iDemand);
+  source = posI(iBest);
+  target = posJ(iBest);
 
-  [edgeI,edgeJ,weight] = find(triu(A,1));
-  G = graph(double(edgeI),double(edgeJ),double(weight),n);
-  [~,~,sourceSide] = maxflow(G,source,target);
+  [edgeI,edgeJ,weight] = find(triu(ABlock,1));
+  G = graph(double(edgeI),double(edgeJ),double(weight),numNodes);
+  [~,~,sourceNodes] = maxflow(G,source,target);
 
-  inSource = false(n,1);
-  inSource(sourceSide) = true;
-  isCut = inSource(edgeI) ~= inSource(edgeJ);
+  sourceSide = false(numNodes,1);
+  sourceSide(sourceNodes) = true;
+  isCut = sourceSide(edgeI) ~= sourceSide(edgeJ);
 
   if ~any(isCut)
     error('MTEX:calcGrains:boundaryCompletionFailed', ...
       'Could not separate an inner grain-boundary constraint.');
   end
 
-  newI = edgeI(isCut);
-  newJ = edgeJ(isCut);
-  cutI{end+1,1} = newI; %#ok<AGROW>
-  cutJ{end+1,1} = newJ; %#ok<AGROW>
+  numCuts = numCuts + 1;
+  cutI{numCuts} = nodes(edgeI(isCut));
+  cutJ{numCuts} = nodes(edgeJ(isCut));
 
-  cut = sparse([newI;newJ],[newJ;newI],true,n,n);
-  A = A - A .* cut;
-  componentId = connectedComponents(A);
+  % Split only the two sides of this cut. The source side is normally
+  % connected already; connectedComponents also handles the rare case in
+  % which the other side contains several components.
+  for onSourceSide = [true false]
+    demandOnSide = sourceSide(posI) == onSourceSide & ...
+      sourceSide(posJ) == onSourceSide;
+    if ~any(demandOnSide), continue; end
+
+    childLocal = find(sourceSide == onSourceSide);
+    childComponent = connectedComponents(ABlock(childLocal,childLocal));
+
+    componentInBlock = zeros(numNodes,1);
+    componentInBlock(childLocal) = childComponent;
+    demandComponent = componentInBlock(posI(demandOnSide));
+    sameComponent = demandComponent == componentInBlock(posJ(demandOnSide));
+    if ~any(sameComponent), continue; end
+
+    childDemands = demands(demandOnSide);
+    childDemands = childDemands(sameComponent);
+    demandComponent = demandComponent(sameComponent);
+
+    componentIds = unique(demandComponent);
+    for iComponent = 1:numel(componentIds)
+      cId = componentIds(iComponent);
+      tail = tail + 1;
+      nodeQueue{tail} = nodes(childLocal(childComponent == cId));
+      demandQueue{tail} = childDemands(demandComponent == cId);
+    end
+  end
 end
 
-cutI = vertcat(cutI{:});
-cutJ = vertcat(cutJ{:});
+cutI = vertcat(cutI{1:numCuts});
+cutJ = vertcat(cutJ{1:numCuts});
+
+end
+
+% -------------------------------------------------------------------------
+function [ignoreI,ignoreJ] = shortIsolatedBoundaries(A_Db,componentId,I_FD,F)
+% find enclosed inner-boundary components with fewer than three segments
+
+ignoreI = zeros(0,1);
+ignoreJ = zeros(0,1);
+componentId = componentId(:);
+
+nFaces = size(I_FD,1);
+if nFaces == 0 || size(F,1) ~= nFaces || size(F,2) ~= 2, return; end
+
+% Extract paired and single-pixel faces directly from the sparse incidence
+% list. Avoiding a dense nFaces-by-2 array matters for large maps.
+I_FDt = I_FD.';
+[pixelId,faceId] = find(I_FDt);
+if isempty(faceId), return; end
+
+sameAsPrevious = [false; faceId(2:end) == faceId(1:end-1)];
+sameAsNext = [faceId(1:end-1) == faceId(2:end); false];
+pairFaceId = faceId(sameAsPrevious);
+pair = [pixelId(sameAsNext),pixelId(sameAsPrevious)];
+singleFaceId = faceId(~sameAsPrevious & ~sameAsNext);
+
+pairIndex = sub2ind(size(A_Db),pair(:,1),pair(:,2));
+isBoundary = full(A_Db(pairIndex)) ~= 0;
+isInner = isBoundary & ...
+  componentId(pair(:,1)) == componentId(pair(:,2));
+if ~any(isInner), return; end
+
+innerFaceId = pairFaceId(isInner);
+innerSegments = double(F(innerFaceId,:));
+if any(innerSegments(:) < 1), return; end
+
+% Boundary segments are connected exactly when their rows in F share a
+% Voronoi vertex. Only the (usually small) set of inner segments enters this
+% sparse product.
+numInner = numel(innerFaceId);
+numVertices = double(max(F(:)));
+I_VB = sparse(innerSegments(:),[(1:numInner).';(1:numInner).'], ...
+  true,numVertices,numInner);
+boundaryComponent = connectedComponents(I_VB.' * I_VB);
+boundaryComponent = boundaryComponent(:);
+
+% Existing inter-grain boundaries and the exterior of the measured map both
+% count as outer boundaries.
+isOuterPair = isBoundary & ...
+  componentId(pair(:,1)) ~= componentId(pair(:,2));
+outerFaceId = [singleFaceId;pairFaceId(isOuterPair)];
+
+outerVertex = false(numVertices,1);
+outerSegments = double(F(outerFaceId,:));
+outerSegments = outerSegments(outerSegments > 0);
+outerVertex(outerSegments) = true;
+touchesOuter = any(outerVertex(innerSegments),2);
+
+numComponents = max(boundaryComponent);
+componentSize = accumarray(boundaryComponent(:),1,[numComponents 1]);
+componentTouchesOuter = accumarray(boundaryComponent(:),touchesOuter, ...
+  [numComponents 1],@(x) any(x),false);
+
+ignore = componentSize(boundaryComponent) < 3 & ...
+  ~componentTouchesOuter(boundaryComponent);
+innerPairs = pair(isInner,:);
+ignoredPairs = unique(sort(innerPairs(ignore,:),2),'rows');
+ignoreI = ignoredPairs(:,1);
+ignoreJ = ignoredPairs(:,2);
 
 end

--- a/EBSDAnalysis/@EBSD/private/doSegmentation.m
+++ b/EBSDAnalysis/@EBSD/private/doSegmentation.m
@@ -1,8 +1,9 @@
-function [A_Db,I_DG] = doSegmentation(I_FD,ebsd,gbc,varargin)
+function [A_Db,I_DG] = doSegmentation(I_FD,F,ebsd,gbc,varargin)
 % segments voronoi cells into grains
 %
 % Input
 %  I_FD - incidence matrix faces -> pixels
+%  F - vertex ids of the boundary segments
 %  ebsd - @EBSD
 %  gbc - @grainBoundaryCriterion
 %
@@ -42,7 +43,7 @@ A_Do = A_Do | A_Do.';
 A_Db = A_Db | A_Db.';
 
 if check_option(varargin,'completeBoundaries')
-  [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db);
+  [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db,I_FD,F);
 else
   componentId = connectedComponents(A_Do);
 end

--- a/EBSDAnalysis/@EBSD/private/doSegmentation.m
+++ b/EBSDAnalysis/@EBSD/private/doSegmentation.m
@@ -9,7 +9,6 @@ function [A_Db,I_DG] = doSegmentation(I_FD,ebsd,gbc,varargin)
 % Output
 %  I_DG - incidence matrix pixels -> grains
 %  A_Db - adjacency matrix of grain boundaries
-%  A_Do - adjacency matrix inside grain connections
 %
 
 % get pairs of neighboring cells {D_l,D_r} in A_D
@@ -42,8 +41,14 @@ A_Do = A_Do | A_Do.';
 % adjacency of cells that have a common boundary
 A_Db = A_Db | A_Db.';
 
+if check_option(varargin,'completeBoundaries')
+  [A_Do,A_Db,componentId] = completeBoundaryGraph(A_Do,A_Db);
+else
+  componentId = connectedComponents(A_Do);
+end
+
 % compute I_DG connected components of A_Do
 % I_DG - incidence matrix cells to grains
-I_DG = sparse(1:length(ebsd),double(connectedComponents(A_Do)),1);
+I_DG = sparse(1:length(ebsd),double(componentId),1);
 
 end

--- a/EBSDAnalysis/@EBSD/private/minPixelMask.m
+++ b/EBSDAnalysis/@EBSD/private/minPixelMask.m
@@ -44,7 +44,12 @@ if strcmpi(minPixelMethod,'grid')
 else
   out0  = spatialDecompositionGrid(ebsd,varargin{:},'delaunayOnly');
   I_FD0 = remapIFD(out0,ebsd);
-  [~,I_DG0] = doSegmentation(I_FD0,ebsd,gbc,varargin{:});
+
+  % Boundary completion can only split these preliminary grains. Keeping the
+  % unsplit sizes is conservative (it cannot over-cull) and avoids running
+  % the same expensive max-flow problems again during the sizing pass.
+  segmentationOptions = delete_option(varargin,'completeBoundaries');
+  [~,I_DG0] = doSegmentation(I_FD0,out0.F,ebsd,gbc,segmentationOptions{:});
   gid0 = full(I_DG0 * (1:size(I_DG0,2)).');       % grain id per pixel (0 = none)
 end
 

--- a/EBSDAnalysis/@EBSD/private/minPixelMask.m
+++ b/EBSDAnalysis/@EBSD/private/minPixelMask.m
@@ -47,7 +47,7 @@ else
 
   % Boundary completion can only split these preliminary grains. Keeping the
   % unsplit sizes is conservative (it cannot over-cull) and avoids running
-  % the same expensive max-flow problems again during the sizing pass.
+  % the same boundary-completion paths again during the sizing pass.
   segmentationOptions = delete_option(varargin,'completeBoundaries');
   [~,I_DG0] = doSegmentation(I_FD0,out0.F,ebsd,gbc,segmentationOptions{:});
   gid0 = full(I_DG0 * (1:size(I_DG0,2)).');       % grain id per pixel (0 = none)

--- a/EBSDAnalysis/functionSignatures.json
+++ b/EBSDAnalysis/functionSignatures.json
@@ -34,7 +34,8 @@
       {"name":"ebsd", "kind":"required",   "type":"EBSD"},
       {"name":"angle", "kind":"namevalue", "type":"double"},
       {"name":"minPixel", "kind":"namevalue", "type":"double"},
-      {"name":"alpha", "kind":"namevalue", "type":"double"}
+      {"name":"alpha", "kind":"namevalue", "type":"double"},
+      {"name":"completeBoundaries", "kind":"flag"}
     ]
 },
 "rotate":

--- a/tests/check_calcGrainsCases.m
+++ b/tests/check_calcGrainsCases.m
@@ -134,6 +134,52 @@ if numel(ebsdQP2.grainId) ~= numel(ebsdQP2)
     numel(ebsdQP2.grainId), numel(ebsdQP2));
 end
 
+%% completeBoundaries: close a one-edge bridge between two grains
+%
+% The two halves differ by 10 degrees, except for one neighboring pair at
+% the interface with orientations 4 and 6 degrees. With a 5 degree
+% threshold this single pair connects both halves under the standard
+% connected-component definition. Boundary completion must cut the bridge
+% and turn the otherwise inner boundary into an external grain boundary.
+
+n = 10;
+mid = n/2;
+bridgeRow = n/2;
+oriLeft = orientation.id(cs);
+oriRight = orientation.byAxisAngle(zvector,10*degree,cs);
+
+rot = rotation.id(n,n);
+rot(:,1:mid) = oriLeft;
+rot(:,mid+1:end) = oriRight;
+rot(bridgeRow,mid) = orientation.byAxisAngle(zvector,4*degree,cs);
+rot(bridgeRow,mid+1) = orientation.byAxisAngle(zvector,6*degree,cs);
+
+ebsdBridge = EBSDsquare([],rot,ones(size(rot)),1,{cs},'dxy',[1 1]);
+gConnected = calcGrains(ebsdBridge,'threshold',thr);
+gCompleted = calcGrains(ebsdBridge,'threshold',thr,'completeBoundaries');
+
+if length(gConnected) ~= 1
+  error('bridge case: standard reconstruction should return one grain, got %d', ...
+    length(gConnected));
+end
+
+if length(gConnected.innerBoundary) == 0
+  error('bridge case: standard reconstruction did not expose the inner boundary');
+end
+
+if length(gCompleted) ~= 2
+  error('bridge case: boundary completion should return two grains, got %d', ...
+    length(gCompleted));
+end
+
+if length(gCompleted.innerBoundary) ~= 0
+  error('bridge case: completed reconstruction still contains inner boundaries');
+end
+
+if any(sort(gCompleted.numPixel) ~= [50;50])
+  error('bridge case: expected two grains with 50 pixels each');
+end
+
 disp('calcGrains cases: all checks passed');
 
 end

--- a/tests/check_calcGrainsCases.m
+++ b/tests/check_calcGrainsCases.m
@@ -236,6 +236,10 @@ if length(gNoise) ~= 2 || length(gNoise.innerBoundary) ~= 0
   error(['noise case: an enclosed three-segment boundary must be retained ' ...
     'and completed']);
 end
+if any(gNoise.numPixel == 1)
+  error(['noise case: boundary completion must extend to non-inner ' ...
+    'boundaries instead of closing a loop around the centre pixel']);
+end
 
 %% completeBoundaries: retain a short fragment that reaches the map boundary
 

--- a/tests/check_calcGrainsCases.m
+++ b/tests/check_calcGrainsCases.m
@@ -180,6 +180,82 @@ if any(sort(gCompleted.numPixel) ~= [50;50])
   error('bridge case: expected two grains with 50 pixels each');
 end
 
+%% completeBoundaries: ignore enclosed one- and two-segment fragments
+%
+% A 3 degree background, one 0 degree centre pixel and selected 6 degree
+% neighbours produce isolated >5 degree faces while every alternative
+% connection stays below the threshold. Enclosed components with one or two
+% segments are treated as pixel noise. Three segments are retained and must
+% be completed.
+
+nNoise = 7;
+c = (nNoise+1)/2;
+neighbours = [c,c+1; c-1,c; c,c-1];
+oriMid = orientation.byAxisAngle(zvector,3*degree,cs);
+oriHigh = orientation.byAxisAngle(zvector,6*degree,cs);
+
+for numSegments = 1:2
+  rotNoise = rotation.id(nNoise,nNoise);
+  rotNoise(:) = oriMid;
+  rotNoise(c,c) = orientation.id(cs);
+  for k = 1:numSegments
+    rotNoise(neighbours(k,1),neighbours(k,2)) = oriHigh;
+  end
+
+  ebsdNoise = EBSDsquare([],rotNoise,ones(size(rotNoise)),1,{cs},'dxy',[1 1]);
+  gNoiseRaw = calcGrains(ebsdNoise,'threshold',thr);
+  gNoise = calcGrains(ebsdNoise,'threshold',thr,'completeBoundaries');
+
+  if length(gNoiseRaw.innerBoundary) ~= numSegments
+    error('noise case: expected %d inner segments, got %d', ...
+      numSegments,length(gNoiseRaw.innerBoundary));
+  end
+  if length(gNoise) ~= 1 || length(gNoise.innerBoundary) ~= 0
+    error(['noise case: an enclosed %d-segment boundary fragment should ' ...
+      'be ignored without splitting the grain'],numSegments);
+  end
+end
+
+gNoiseMinPixel = calcGrains(ebsdNoise,'threshold',thr,'minPixel',2, ...
+  'completeBoundaries');
+if length(gNoiseMinPixel) ~= 1 || length(gNoiseMinPixel.innerBoundary) ~= 0
+  error(['noise case: the conservative minPixel sizing pass must preserve ' ...
+    'the ignored short boundary fragment']);
+end
+
+rotNoise = rotation.id(nNoise,nNoise);
+rotNoise(:) = oriMid;
+rotNoise(c,c) = orientation.id(cs);
+for k = 1:3
+  rotNoise(neighbours(k,1),neighbours(k,2)) = oriHigh;
+end
+
+ebsdNoise = EBSDsquare([],rotNoise,ones(size(rotNoise)),1,{cs},'dxy',[1 1]);
+gNoise = calcGrains(ebsdNoise,'threshold',thr,'completeBoundaries');
+if length(gNoise) ~= 2 || length(gNoise.innerBoundary) ~= 0
+  error(['noise case: an enclosed three-segment boundary must be retained ' ...
+    'and completed']);
+end
+
+%% completeBoundaries: retain a short fragment that reaches the map boundary
+
+rotEdge = rotation.id(nNoise,nNoise);
+rotEdge(:) = oriMid;
+rotEdge(1,c) = orientation.id(cs);
+rotEdge(1,c+1) = oriHigh;
+
+ebsdEdge = EBSDsquare([],rotEdge,ones(size(rotEdge)),1,{cs},'dxy',[1 1]);
+gEdgeRaw = calcGrains(ebsdEdge,'threshold',thr);
+gEdge = calcGrains(ebsdEdge,'threshold',thr,'completeBoundaries');
+
+if length(gEdgeRaw.innerBoundary) ~= 1
+  error('edge case: expected one inner boundary segment');
+end
+if length(gEdge) ~= 2 || length(gEdge.innerBoundary) ~= 0
+  error(['edge case: a short inner boundary connected to the map boundary ' ...
+    'must be retained and completed']);
+end
+
 disp('calcGrains cases: all checks passed');
 
 end


### PR DESCRIPTION
## Summary

- add an opt-in `completeBoundaries` flag to `calcGrains`
- represent Voronoi boundary segments as a compact grain-local dual graph
- extend every retained inner-boundary network until all of its free ends reach existing non-inner boundaries
- allow an augmentation to connect different boundary components, but never reconnect one component to itself
- ignore enclosed inner-boundary components shorter than three segments
- add bridge, noise-fragment, map-edge, `minPixel`, and isolated-pixel-loop regression cases

## Motivation

Connected-component reconstruction can merge otherwise distinct grains when only one sub-threshold neighboring pixel pair bridges them. The detected interfaces then remain as self-boundaries inside the merged grain.

An unconstrained pixel minimum cut tends to isolate a single boundary pixel because that is often the cheapest cut. Boundary completion is therefore performed in the planar dual graph instead: retained boundary chains are extended along Voronoi segments until the resulting network is anchored at non-inner boundaries.

## Loop prevention

For each free boundary endpoint, admissible targets are either:

- a vertex on an existing inter-grain or exterior map boundary, or
- a free endpoint belonging to a different boundary component

All other vertices of the active boundary network are blocked while finding the path. Consequently, an added path cannot connect a boundary component back to itself and cannot close a new loop around an isolated pixel. Once different components are joined, their remaining free ends are still extended until the complete network terminates at non-inner boundaries.

## Performance

- replaces repeated grain-sized pixel max-flow problems with unweighted shortest paths in the boundary-segment dual
- processes only grains containing retained inner boundaries
- uses compact local vertex ids, avoiding graph objects with map-sized ranges of isolated vertices
- filters short enclosed noise fragments before constructing path problems
- keeps the conservative unsplit grain sizes in the preliminary `minPixel` pass, so completion is not run twice

The path sequence is greedy: every augmentation uses the smallest currently available number of new segments, but the complete result is not claimed to be a globally optimal Steiner forest.

## Compatibility

Default reconstruction is unchanged unless `completeBoundaries` is supplied. One- and two-segment enclosed fragments are removed as noise; equally short fragments touching a pre-existing non-inner boundary are retained.

## Validation

- connector branch contents verified byte-for-byte against the workspace
- function-signature JSON and Git whitespace/static checks pass
- equivalent square-grid graph simulations preserve the 50/50 bridge split and extend a three-segment U-shaped fragment to the exterior without producing a one-pixel grain
- MATLAB regression cases are included but could not be executed because this workspace has no MATLAB or Octave runtime
