### PR TITLE
Remove duplicate "EBSDOrientationPlots" from TOC

### DIFF
--- a/doc/EBSDAnalysis/EBSDAnalysis.toc
+++ b/doc/EBSDAnalysis/EBSDAnalysis.toc
@@ -13,7 +13,6 @@ EBSDFilling           Filling Missing Data
 EBSDPseudoSymmetry    Pseudo Symmetry
 EBSDInter             Regridding and Interpolation
 EBSD2ODF              ODF Estimation
-EBSDOrientationPlots  Orientation Plots
 EBSDSharpPlot         Sharp Color Keys 
 EBSDAdvancedMaps      Advanced Plotting
 EBSDKAM               KAM


### PR DESCRIPTION
Removed 'EBSDOrientationPlots' entry from the table of contents, it was duplicated.